### PR TITLE
feat(ReplaceDocument): add state field when updating document

### DIFF
--- a/src/components/ReplaceDocument.tsx
+++ b/src/components/ReplaceDocument.tsx
@@ -125,6 +125,7 @@ export default function ReplaceDocument({
             document_path: finalDocument?.path,
             validity: filename.validity ? new Date(filename.validity).toISOString() : null,
             created_at: new Date().toISOString(),
+            state: 'presentado'
           })
           .eq('id', appliesId || '');
 


### PR DESCRIPTION
The 'presentado' state is now set by default when updating a document to track submission status.