### PR TITLE
Add módulo Configuración con CRUD de Puestos y Diagramas por empresa

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,6 +281,8 @@ model company {
   hse_doc_types          hse_doc_types[]
   hse_document_tags      hse_document_tags[]
   documentsCompanies     documents_company[]
+  hierarchy              hierarchy[]
+  work_diagram           work_diagram[]
 
   // Almacenes y Compras
   products                    products[]
@@ -306,7 +308,9 @@ model hierarchy {
   created_at DateTime @default(now()) @db.Timestamptz
   name       String
   is_active  Boolean? @default(true)
+  company_id String?  @db.Uuid
 
+  company   company?    @relation(fields: [company_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
   employees employees[]
 }
 
@@ -480,7 +484,9 @@ model work_diagram {
   created_at DateTime @default(now()) @db.Timestamptz
   name       String
   is_active  Boolean? @default(true)
+  company_id String?  @db.Uuid
 
+  company   company?    @relation(fields: [company_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
   employees employees[]
 
   @@map("work-diagram")

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react';
+import SettingsView from '@/modules/settings/features/parameters/components/SettingsView';
+import PageTableSkeleton from '@/shared/components/common/Skeletons/PageTableSkeleton';
+
+export default async function SettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const resolved = await searchParams;
+
+  return (
+    <Suspense fallback={<PageTableSkeleton />}>
+      <SettingsView currentTab={resolved.tab} />
+    </Suspense>
+  );
+}

--- a/src/modules/employees/shared/utils.ts
+++ b/src/modules/employees/shared/utils.ts
@@ -11,7 +11,10 @@ export const fetchWorkDiagrams = async () => {
 
   try {
     const data = await prisma.work_diagram.findMany({
-      where: { is_active: true },
+      where: {
+        is_active: true,
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
       select: { id: true, name: true },
     });
     return data;
@@ -51,9 +54,15 @@ export const fetchCovenants = async () => {
 };
 
 export const fetchHierrarchicalPositions = async () => {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
   try {
     const data = await prisma.hierarchy.findMany({
-      where: { is_active: true },
+      where: {
+        is_active: true,
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
     });
     return data;
   } catch (error) {

--- a/src/modules/settings/features/parameters/actions.server.ts
+++ b/src/modules/settings/features/parameters/actions.server.ts
@@ -1,0 +1,232 @@
+'use server';
+
+import { prisma } from '@/shared/lib/prisma';
+import { getActionContext } from '@/shared/lib/server-action-context';
+import { revalidatePath } from 'next/cache';
+
+// ============================================================
+// Hierarchy (Puestos Jerárquicos)
+// ============================================================
+
+export async function getHierarchyParameters() {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  try {
+    return await prisma.hierarchy.findMany({
+      where: { OR: [{ company_id: companyId }, { company_id: null }] },
+      orderBy: [{ is_active: 'desc' }, { name: 'asc' }],
+    });
+  } catch (error) {
+    console.error('Error in getHierarchyParameters:', error);
+    return [];
+  }
+}
+
+export async function createHierarchyParameter(name: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  const trimmed = name.trim();
+  if (!trimmed) return { error: 'El nombre no puede estar vacío' };
+
+  try {
+    const existing = await prisma.hierarchy.findFirst({
+      where: {
+        name: { equals: trimmed, mode: 'insensitive' },
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
+      select: { id: true, company_id: true },
+    });
+    if (existing) {
+      return { error: 'Ya existe un puesto con ese nombre' };
+    }
+
+    await prisma.hierarchy.create({
+      data: { name: trimmed, company_id: companyId, is_active: true },
+    });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error creating hierarchy:', error);
+    return { error: String(error) };
+  }
+}
+
+export async function updateHierarchyParameter(id: string, name: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  const trimmed = name.trim();
+  if (!trimmed) return { error: 'El nombre no puede estar vacío' };
+
+  try {
+    const current = await prisma.hierarchy.findUnique({ where: { id } });
+    if (!current) return { error: 'Puesto no encontrado' };
+    if (current.company_id && current.company_id !== companyId) {
+      return { error: 'No se puede editar un puesto de otra empresa' };
+    }
+    if (current.company_id === null) {
+      return { error: 'No se puede editar un puesto de catálogo del sistema' };
+    }
+
+    const duplicate = await prisma.hierarchy.findFirst({
+      where: {
+        id: { not: id },
+        name: { equals: trimmed, mode: 'insensitive' },
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
+      select: { id: true },
+    });
+    if (duplicate) return { error: 'Ya existe un puesto con ese nombre' };
+
+    await prisma.hierarchy.update({ where: { id }, data: { name: trimmed } });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error updating hierarchy:', error);
+    return { error: String(error) };
+  }
+}
+
+export async function toggleHierarchyParameterActive(id: string, isActive: boolean) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  try {
+    const current = await prisma.hierarchy.findUnique({ where: { id } });
+    if (!current) return { error: 'Puesto no encontrado' };
+    if (current.company_id && current.company_id !== companyId) {
+      return { error: 'No se puede modificar un puesto de otra empresa' };
+    }
+    if (current.company_id === null) {
+      return { error: 'No se puede modificar un puesto de catálogo del sistema' };
+    }
+
+    await prisma.hierarchy.update({ where: { id }, data: { is_active: isActive } });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error toggling hierarchy:', error);
+    return { error: String(error) };
+  }
+}
+
+// ============================================================
+// Work Diagram (Diagramas de Trabajo)
+// ============================================================
+
+export async function getWorkDiagramParameters() {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  try {
+    return await prisma.work_diagram.findMany({
+      where: { OR: [{ company_id: companyId }, { company_id: null }] },
+      orderBy: [{ is_active: 'desc' }, { name: 'asc' }],
+    });
+  } catch (error) {
+    console.error('Error in getWorkDiagramParameters:', error);
+    return [];
+  }
+}
+
+export async function createWorkDiagramParameter(name: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  const trimmed = name.trim();
+  if (!trimmed) return { error: 'El nombre no puede estar vacío' };
+
+  try {
+    const existing = await prisma.work_diagram.findFirst({
+      where: {
+        name: { equals: trimmed, mode: 'insensitive' },
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
+      select: { id: true },
+    });
+    if (existing) return { error: 'Ya existe un diagrama con ese nombre' };
+
+    await prisma.work_diagram.create({
+      data: { name: trimmed, company_id: companyId, is_active: true },
+    });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error creating work diagram:', error);
+    return { error: String(error) };
+  }
+}
+
+export async function updateWorkDiagramParameter(id: string, name: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  const trimmed = name.trim();
+  if (!trimmed) return { error: 'El nombre no puede estar vacío' };
+
+  try {
+    const current = await prisma.work_diagram.findUnique({ where: { id } });
+    if (!current) return { error: 'Diagrama no encontrado' };
+    if (current.company_id && current.company_id !== companyId) {
+      return { error: 'No se puede editar un diagrama de otra empresa' };
+    }
+    if (current.company_id === null) {
+      return { error: 'No se puede editar un diagrama de catálogo del sistema' };
+    }
+
+    const duplicate = await prisma.work_diagram.findFirst({
+      where: {
+        id: { not: id },
+        name: { equals: trimmed, mode: 'insensitive' },
+        OR: [{ company_id: companyId }, { company_id: null }],
+      },
+      select: { id: true },
+    });
+    if (duplicate) return { error: 'Ya existe un diagrama con ese nombre' };
+
+    await prisma.work_diagram.update({ where: { id }, data: { name: trimmed } });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error updating work diagram:', error);
+    return { error: String(error) };
+  }
+}
+
+export async function toggleWorkDiagramParameterActive(id: string, isActive: boolean) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company context' };
+
+  try {
+    const current = await prisma.work_diagram.findUnique({ where: { id } });
+    if (!current) return { error: 'Diagrama no encontrado' };
+    if (current.company_id && current.company_id !== companyId) {
+      return { error: 'No se puede modificar un diagrama de otra empresa' };
+    }
+    if (current.company_id === null) {
+      return { error: 'No se puede modificar un diagrama de catálogo del sistema' };
+    }
+
+    await prisma.work_diagram.update({ where: { id }, data: { is_active: isActive } });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error toggling work diagram:', error);
+    return { error: String(error) };
+  }
+}
+
+// ============================================================
+// Type of Contract (read-only, enum del sistema — Fase 2 lo convierte en tabla)
+// ============================================================
+
+export async function getTypeOfContractValues() {
+  // Hardcoded del enum type_of_contract_enum
+  return [
+    { id: 'Periodo_de_prueba', name: 'Período de prueba', is_active: true },
+    { id: 'A_tiempo_indeterminado', name: 'A tiempo indeterminado', is_active: true },
+    { id: 'Plazo_fijo', name: 'Plazo fijo', is_active: true },
+  ];
+}

--- a/src/modules/settings/features/parameters/components/ParameterCrudTable.tsx
+++ b/src/modules/settings/features/parameters/components/ParameterCrudTable.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Badge } from '@/shared/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+import { Pencil, Plus, Power } from 'lucide-react';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+
+export interface ParameterRow {
+  id: string;
+  name: string;
+  is_active: boolean | null;
+  company_id: string | null;
+}
+
+interface Props {
+  title: string;
+  entityLabel: string;
+  items: ParameterRow[];
+  createAction: (name: string) => Promise<{ error: string | null }>;
+  updateAction: (id: string, name: string) => Promise<{ error: string | null }>;
+  toggleActiveAction: (id: string, isActive: boolean) => Promise<{ error: string | null }>;
+}
+
+export function ParameterCrudTable({
+  title,
+  entityLabel,
+  items,
+  createAction,
+  updateAction,
+  toggleActiveAction,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<ParameterRow | null>(null);
+  const [name, setName] = useState('');
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingToggle, setPendingToggle] = useState<ParameterRow | null>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setName('');
+    setDialogOpen(true);
+  };
+
+  const openEdit = (item: ParameterRow) => {
+    setEditing(item);
+    setName(item.name);
+    setDialogOpen(true);
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error('El nombre no puede estar vacío');
+      return;
+    }
+    startTransition(async () => {
+      const result = editing ? await updateAction(editing.id, trimmed) : await createAction(trimmed);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(editing ? `${entityLabel} actualizado` : `${entityLabel} creado`);
+      setDialogOpen(false);
+      router.refresh();
+    });
+  };
+
+  const handleToggle = async () => {
+    if (!pendingToggle) return;
+    const newState = !pendingToggle.is_active;
+    startTransition(async () => {
+      const result = await toggleActiveAction(pendingToggle.id, newState);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(newState ? `${entityLabel} habilitado` : `${entityLabel} deshabilitado`);
+      setConfirmOpen(false);
+      setPendingToggle(null);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <Button size="sm" onClick={openCreate}>
+          <Plus className="size-4 mr-1" /> Nuevo
+        </Button>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nombre</TableHead>
+              <TableHead className="w-[140px]">Origen</TableHead>
+              <TableHead className="w-[120px]">Estado</TableHead>
+              <TableHead className="w-[120px] text-right">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center py-6 text-muted-foreground">
+                  Sin registros. Agregá el primero con &quot;Nuevo&quot;.
+                </TableCell>
+              </TableRow>
+            ) : (
+              items.map((item) => {
+                const isSeed = item.company_id === null;
+                return (
+                  <TableRow key={item.id} className={!item.is_active ? 'opacity-60' : ''}>
+                    <TableCell className="font-medium">{item.name}</TableCell>
+                    <TableCell>
+                      {isSeed ? (
+                        <Badge variant="outline" className="text-xs">Sistema</Badge>
+                      ) : (
+                        <Badge variant="secondary" className="text-xs">Propio</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={item.is_active ? 'default' : 'destructive'}>
+                        {item.is_active ? 'Activo' : 'Inactivo'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {!isSeed && (
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8"
+                            onClick={() => openEdit(item)}
+                            title="Editar"
+                          >
+                            <Pencil className="size-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8"
+                            onClick={() => {
+                              setPendingToggle(item);
+                              setConfirmOpen(true);
+                            }}
+                            title={item.is_active ? 'Deshabilitar' : 'Habilitar'}
+                          >
+                            <Power className="size-4" />
+                          </Button>
+                        </div>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editing ? `Editar ${entityLabel.toLowerCase()}` : `Nuevo ${entityLabel.toLowerCase()}`}
+            </DialogTitle>
+            <DialogDescription>
+              {editing ? 'Modificá el nombre y guardá.' : `Ingresá el nombre del nuevo ${entityLabel.toLowerCase()}.`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Nombre"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSubmit();
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={isPending}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSubmit} disabled={isPending}>
+              {isPending ? 'Guardando...' : 'Guardar'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingToggle?.is_active ? 'Deshabilitar' : 'Habilitar'} {entityLabel.toLowerCase()}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingToggle?.is_active
+                ? `Los empleados que ya tienen "${pendingToggle?.name}" asignado conservan el valor, pero no aparecerá en nuevas asignaciones.`
+                : `"${pendingToggle?.name}" volverá a estar disponible para asignar a empleados.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleToggle} disabled={isPending}>
+              {isPending ? 'Procesando...' : 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/modules/settings/features/parameters/components/SettingsView.tsx
+++ b/src/modules/settings/features/parameters/components/SettingsView.tsx
@@ -1,0 +1,143 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
+import {
+  UrlTabs,
+  UrlTabsContent,
+  UrlTabsList,
+  UrlTabsTrigger,
+} from '@/shared/components/ui/url-tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/components/ui/table';
+import { Badge } from '@/shared/components/ui/badge';
+import { ParameterCrudTable } from './ParameterCrudTable';
+import {
+  createHierarchyParameter,
+  createWorkDiagramParameter,
+  getHierarchyParameters,
+  getTypeOfContractValues,
+  getWorkDiagramParameters,
+  toggleHierarchyParameterActive,
+  toggleWorkDiagramParameterActive,
+  updateHierarchyParameter,
+  updateWorkDiagramParameter,
+} from '../actions.server';
+
+const VALID_TABS = ['hierarchy', 'work-diagram', 'contract-type'] as const;
+type SettingsTab = (typeof VALID_TABS)[number];
+
+interface Props {
+  currentTab?: string;
+}
+
+export default async function SettingsView({ currentTab }: Props) {
+  const tab: SettingsTab = VALID_TABS.includes(currentTab as SettingsTab)
+    ? (currentTab as SettingsTab)
+    : 'hierarchy';
+
+  const [hierarchy, workDiagrams, contractTypes] = await Promise.all([
+    getHierarchyParameters(),
+    getWorkDiagramParameters(),
+    getTypeOfContractValues(),
+  ]);
+
+  return (
+    <UrlTabs value={tab} paramName="tab" baseUrl="/dashboard/settings">
+      <UrlTabsList>
+        <UrlTabsTrigger value="hierarchy">Puestos jerárquicos</UrlTabsTrigger>
+        <UrlTabsTrigger value="work-diagram">Diagramas de trabajo</UrlTabsTrigger>
+        <UrlTabsTrigger value="contract-type">Tipo de contrato</UrlTabsTrigger>
+      </UrlTabsList>
+
+      <UrlTabsContent value="hierarchy">
+        <Card>
+          <CardHeader>
+            <CardTitle>Puestos jerárquicos</CardTitle>
+            <CardDescription>
+              Categorías de puestos que se asignan a los empleados. Los marcados como
+              &quot;Sistema&quot; son del catálogo base y no se pueden modificar.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ParameterCrudTable
+              title="Listado"
+              entityLabel="Puesto"
+              items={hierarchy.map((h) => ({
+                id: h.id,
+                name: h.name,
+                is_active: h.is_active,
+                company_id: h.company_id,
+              }))}
+              createAction={createHierarchyParameter}
+              updateAction={updateHierarchyParameter}
+              toggleActiveAction={toggleHierarchyParameterActive}
+            />
+          </CardContent>
+        </Card>
+      </UrlTabsContent>
+
+      <UrlTabsContent value="work-diagram">
+        <Card>
+          <CardHeader>
+            <CardTitle>Diagramas de trabajo</CardTitle>
+            <CardDescription>
+              Turnos o esquemas laborales (por ej. 6x1, 5x2, 14x7). Se asignan a los empleados.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ParameterCrudTable
+              title="Listado"
+              entityLabel="Diagrama"
+              items={workDiagrams.map((w) => ({
+                id: w.id,
+                name: w.name,
+                is_active: w.is_active,
+                company_id: w.company_id,
+              }))}
+              createAction={createWorkDiagramParameter}
+              updateAction={updateWorkDiagramParameter}
+              toggleActiveAction={toggleWorkDiagramParameterActive}
+            />
+          </CardContent>
+        </Card>
+      </UrlTabsContent>
+
+      <UrlTabsContent value="contract-type">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tipo de contrato</CardTitle>
+            <CardDescription>
+              Valores fijos del sistema. Próximamente serán editables por empresa.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Nombre</TableHead>
+                    <TableHead className="w-[140px]">Origen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {contractTypes.map((c) => (
+                    <TableRow key={c.id}>
+                      <TableCell className="font-medium">{c.name}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">Sistema</Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </UrlTabsContent>
+    </UrlTabs>
+  );
+}

--- a/src/shared/actions/catalogs.ts
+++ b/src/shared/actions/catalogs.ts
@@ -1,5 +1,6 @@
 'use server';
 import { prisma } from '@/shared/lib/prisma';
+import { getActionContext } from '@/shared/lib/server-action-context';
 
 // --- From shared/queries.ts ---
 
@@ -124,8 +125,13 @@ export const fetchIndustryTypes = async () => {
 // --- From employees/queries.ts ---
 
 export const fetchHierarchy = async () => {
+  const { companyId } = await getActionContext();
   try {
-    const data = await prisma.hierarchy.findMany();
+    const data = await prisma.hierarchy.findMany({
+      where: companyId
+        ? { OR: [{ company_id: companyId }, { company_id: null }] }
+        : undefined,
+    });
     return data ?? [];
   } catch (error) {
     console.error('Error fetching hierarchy:', error);
@@ -134,8 +140,13 @@ export const fetchHierarchy = async () => {
 };
 
 export const fetchAllWorkDiagrams = async () => {
+  const { companyId } = await getActionContext();
   try {
-    const data = await prisma.work_diagram.findMany();
+    const data = await prisma.work_diagram.findMany({
+      where: companyId
+        ? { OR: [{ company_id: companyId }, { company_id: null }] }
+        : undefined,
+    });
     return data ?? [];
   } catch (error) {
     console.error('Error fetching work diagrams:', error);
@@ -200,9 +211,15 @@ export const fetchAllBrandVehicles = async () => {
 };
 
 export const fetchAllHierarchies = async () => {
+  const { companyId } = await getActionContext();
   try {
     const data = await prisma.hierarchy.findMany({
-      where: { is_active: true },
+      where: {
+        is_active: true,
+        ...(companyId
+          ? { OR: [{ company_id: companyId }, { company_id: null }] }
+          : {}),
+      },
       select: { id: true, name: true },
       orderBy: { name: 'asc' },
     });

--- a/src/shared/components/layout/SideBarContainer.tsx
+++ b/src/shared/components/layout/SideBarContainer.tsx
@@ -8,6 +8,7 @@ import {
   GraduationCap,
   HelpCircle,
   LayoutDashboard,
+  Settings,
   ShoppingCart,
   Truck,
   Users,
@@ -30,10 +31,14 @@ const ALL_LINKS = [
   { name: 'Formularios', href: '/dashboard/forms', icon: <ClipboardList size={sizeIcons} />, position: 9 },
   { name: 'Operaciones', href: '/dashboard/operations', icon: <Calendar size={sizeIcons} />, position: 10 },
   { name: 'HSE', href: '/dashboard/hse', icon: <GraduationCap size={sizeIcons} />, position: 11 },
-  { name: 'Ayuda', href: '/dashboard/help', icon: <HelpCircle size={sizeIcons} />, position: 12 },
+  { name: 'Configuración', href: '/dashboard/settings', icon: <Settings size={sizeIcons} />, position: 12 },
+  { name: 'Ayuda', href: '/dashboard/help', icon: <HelpCircle size={sizeIcons} />, position: 13 },
 ];
 
-const GUEST_HIDDEN = new Set(['empresa', 'operaciones', 'mantenimiento', 'documentacion']);
+const GUEST_HIDDEN = new Set(['empresa', 'operaciones', 'mantenimiento', 'documentacion', 'configuracion']);
+
+// M\u00f3dulos siempre visibles para no-Invitados (no dependen de los m\u00f3dulos contratados)
+const ALWAYS_VISIBLE = new Set(['configuracion']);
 
 const normalize = (s: string) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
 
@@ -47,7 +52,9 @@ function filterLinksByRole(role: string | null, modules: string[]) {
   if (modules.length === 0) return ALL_LINKS;
 
   const modulesNorm = new Set(modules.map(normalize));
-  return ALL_LINKS.filter((link) => modulesNorm.has(normalize(link.name)));
+  return ALL_LINKS.filter(
+    (link) => modulesNorm.has(normalize(link.name)) || ALWAYS_VISIBLE.has(normalize(link.name))
+  );
 }
 
 async function SideBarContainer() {

--- a/supabase/migrations/20260424152139_scope_hierarchy_and_work_diagram_per_company.sql
+++ b/supabase/migrations/20260424152139_scope_hierarchy_and_work_diagram_per_company.sql
@@ -1,0 +1,76 @@
+-- Scopear hierarchy y work-diagram por empresa.
+-- Estrategia:
+--   1. ADD columna company_id (nullable) a ambas tablas.
+--   2. Por cada par (empresa, registro_original) que esté en uso por los empleados,
+--      crear una copia con company_id = <empresa> y re-apuntar el FK del empleado.
+--   3. Los registros originales con company_id NULL se mantienen como "catálogo semilla"
+--      accesible a todas las empresas (se consultan con OR company_id IS NULL desde la app).
+
+BEGIN;
+
+-- Paso 1: ADD columna company_id
+ALTER TABLE "hierarchy"
+  ADD COLUMN IF NOT EXISTS "company_id" uuid REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "work-diagram"
+  ADD COLUMN IF NOT EXISTS "company_id" uuid REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Paso 2.a: Replicar hierarchy por empresa usando un mapeo (old_id, company_id) -> new_id
+-- y re-apuntar los empleados.
+WITH uses AS (
+  SELECT DISTINCT e.hierarchical_position AS old_id, e.company_id
+  FROM employees e
+  JOIN hierarchy h ON h.id = e.hierarchical_position
+  WHERE e.hierarchical_position IS NOT NULL
+    AND e.company_id IS NOT NULL
+    AND h.company_id IS NULL
+),
+inserted AS (
+  INSERT INTO hierarchy (id, created_at, name, is_active, company_id)
+  SELECT gen_random_uuid(), now(), h.name, h.is_active, u.company_id
+  FROM uses u
+  JOIN hierarchy h ON h.id = u.old_id
+  RETURNING id, name, company_id
+),
+-- Mapeo (old_id, company_id) -> new_id por NAME + company (el name original se mantiene)
+mapping AS (
+  SELECT u.old_id, u.company_id, i.id AS new_id
+  FROM uses u
+  JOIN hierarchy h_old ON h_old.id = u.old_id
+  JOIN inserted i ON i.company_id = u.company_id AND i.name = h_old.name
+)
+UPDATE employees e
+SET hierarchical_position = m.new_id
+FROM mapping m
+WHERE e.hierarchical_position = m.old_id
+  AND e.company_id = m.company_id;
+
+-- Paso 2.b: Replicar work-diagram por empresa y re-apuntar empleados.
+WITH uses AS (
+  SELECT DISTINCT e.workflow_diagram AS old_id, e.company_id
+  FROM employees e
+  JOIN "work-diagram" w ON w.id = e.workflow_diagram
+  WHERE e.workflow_diagram IS NOT NULL
+    AND e.company_id IS NOT NULL
+    AND w.company_id IS NULL
+),
+inserted AS (
+  INSERT INTO "work-diagram" (id, created_at, name, is_active, company_id)
+  SELECT gen_random_uuid(), now(), w.name, w.is_active, u.company_id
+  FROM uses u
+  JOIN "work-diagram" w ON w.id = u.old_id
+  RETURNING id, name, company_id
+),
+mapping AS (
+  SELECT u.old_id, u.company_id, i.id AS new_id
+  FROM uses u
+  JOIN "work-diagram" w_old ON w_old.id = u.old_id
+  JOIN inserted i ON i.company_id = u.company_id AND i.name = w_old.name
+)
+UPDATE employees e
+SET workflow_diagram = m.new_id
+FROM mapping m
+WHERE e.workflow_diagram = m.old_id
+  AND e.company_id = m.company_id;
+
+COMMIT;


### PR DESCRIPTION
Etapa 1 del plan de parámetros por empresa:

- Migración SQL: ADD column company_id a hierarchy y work-diagram, replicar cada registro en uso por empresa y re-apuntar el FK de employees. Los registros sin uso quedan con company_id=NULL como catálogo semilla accesible a todas las empresas vía OR company_id IS NULL.
- Schema: hierarchy y work_diagram con company_id opcional + back relation desde company.
- Nueva ruta /dashboard/settings con 3 tabs: Puestos jerárquicos (CRUD), Diagramas de trabajo (CRUD), Tipo de contrato (read-only, Etapa 2 lo convierte a tabla).
- Server actions con guards: no se puede editar un registro de otra empresa ni uno de catálogo semilla (company_id=NULL).
- Link 'Configuración' en sidebar, bypasseando filtro de módulos contratados vía ALWAYS_VISIBLE para no-Invitados.
- Scopear queries existentes de hierarchy/work_diagram en catalogs.ts y employees/shared/utils.ts para que usen OR company_id IS NULL.