### PR TITLE
Reducir egress de Supabase: polling, imágenes, paginación y caché

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,8 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'zktcbhhlcksopklpnubj.supabase.co'
+        hostname: 'zktcbhhlcksopklpnubj.supabase.co',
+        pathname: '/storage/v1/object/public/**'
       },
       {
         protocol: 'https',
@@ -13,7 +14,15 @@ const nextConfig = {
       },
       {
         protocol: 'http',
-        hostname: '127.0.0.1'
+        hostname: '127.0.0.1',
+        port: '54321',
+        pathname: '/storage/v1/object/public/**'
+      },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '54321',
+        pathname: '/storage/v1/object/public/**'
       }
     ]
   }

--- a/src/app/api/employees/diagrams/route.ts
+++ b/src/app/api/employees/diagrams/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/shared/lib/prisma';
 import { apiSuccess, apiError } from '@/shared/lib/api-response';
 import { serializeBigInt } from '@/shared/lib/utils';
+import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -25,10 +26,17 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // Sin employee_id: filtrar por la empresa actual de la cookie.
+  // Antes traía diagramas de TODAS las empresas (bug + egress masivo).
+  const cookiesStore = await cookies();
+  const company_id = searchParams.get('actual') ?? cookiesStore.get('actualComp')?.value;
+  if (!company_id) return apiSuccess({ data: [] });
+
   try {
     const employees_diagram = await prisma.employees_diagram.findMany({
+      where: { employee: { company_id } },
       include: {
-        employee: true,
+        employee: { select: { id: true, firstname: true, lastname: true, company_id: true } },
         diagram_type_rel: true,
       },
     });

--- a/src/app/api/repair_solicitud/route.ts
+++ b/src/app/api/repair_solicitud/route.ts
@@ -27,6 +27,8 @@ export async function GET(request: NextRequest) {
         },
         reparation_type_rel: true,
         repairlogs: {
+          orderBy: { created_at: 'desc' },
+          take: 15,
           include: {
             employee: true,
             user: true,

--- a/src/modules/company/features/list/actions.server.ts
+++ b/src/modules/company/features/list/actions.server.ts
@@ -11,16 +11,6 @@ export const fetchCompaniesByOwner = async (ownerId: string) => {
         share_company_users: { include: { profile: true } },
         city_rel: { select: { name: true, id: true } },
         province_rel: { select: { name: true, id: true } },
-        employees: {
-          include: {
-            city_rel: { select: { name: true } },
-            province_rel: { select: { name: true } },
-            workflow_diagram_rel: { select: { name: true } },
-            hierarchy_rel: { select: { name: true } },
-            birthplace_rel: { select: { name: true } },
-            contractor_employee: { include: { contractor: true } },
-          },
-        },
       },
     });
     return (data ?? []);
@@ -42,16 +32,6 @@ export const fetchSharedCompaniesByProfile = async (profileId: string) => {
             share_company_users: { include: { profile: true } },
             city_rel: { select: { name: true, id: true } },
             province_rel: { select: { name: true, id: true } },
-            employees: {
-              include: {
-                city_rel: { select: { name: true } },
-                province_rel: { select: { name: true } },
-                workflow_diagram_rel: { select: { name: true } },
-                hierarchy_rel: { select: { name: true } },
-                birthplace_rel: { select: { name: true } },
-                contractor_employee: { include: { contractor: true } },
-              },
-            },
           },
         },
       },

--- a/src/modules/hse/features/documents/actions.server.ts
+++ b/src/modules/hse/features/documents/actions.server.ts
@@ -131,6 +131,7 @@ export async function getDocuments(company_id: string, filters?: {
     .select('*,docs_types(id, name,short_description)')
     .eq('company_id', company_id)
     .order('created_at', { ascending: false })
+    .limit(200)
 
   if (filters?.status) {
     query = query.eq('status', filters.status)

--- a/src/modules/maintenance/features/repairs/components/RepairSolicitudesTable/components/RepairModal.tsx
+++ b/src/modules/maintenance/features/repairs/components/RepairSolicitudesTable/components/RepairModal.tsx
@@ -30,6 +30,7 @@ function formatCalendar(dateStr: string): string {
   if (daysDiff < 0 && daysDiff > -7) return `${format(date, 'EEEE', { locale: es })} a las ${format(date, 'h:mm a')}`;
   return format(date, 'dd/MM/yyyy');
 }
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
@@ -216,9 +217,13 @@ function RepairModal({ row, onlyView, action }: { row: any; onlyView?: boolean; 
                       <Card>
                         <Link target="_blank" href={image || ''}>
                           <CardContent className="flex aspect-square items-center justify-center p-1">
-                            <img
+                            <Image
                               src={image}
                               alt={`Imagen ${index + 1}`}
+                              width={400}
+                              height={400}
+                              loading="lazy"
+                              sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                               className="w-full h-full object-cover rounded-lg"
                             />
                           </CardContent>
@@ -238,21 +243,30 @@ function RepairModal({ row, onlyView, action }: { row: any; onlyView?: boolean; 
               <Carousel className="w-full">
                 <CarouselContent className="p-2">
                   {imagesMechanic?.length
-                    ? imagesMechanic?.map((image, index) => (
-                        <CarouselItem key={crypto.randomUUID()} className="md:basis-1/2 lg:basis-1/3  overflow-hidden">
-                          <Card className="">
-                            <Link target="_blank" href={image || ''}>
-                              <CardContent className="flex aspect-square items-center justify-center p-1">
-                                <img
-                                  src={image || ''}
-                                  alt={`Imagen ${index + 1}`}
-                                  className="w-full h-full object-cover rounded-lg"
-                                />
-                              </CardContent>
-                            </Link>
-                          </Card>
-                        </CarouselItem>
-                      ))
+                    ? imagesMechanic?.map((image, index) =>
+                        image ? (
+                          <CarouselItem
+                            key={crypto.randomUUID()}
+                            className="md:basis-1/2 lg:basis-1/3  overflow-hidden"
+                          >
+                            <Card className="">
+                              <Link target="_blank" href={image}>
+                                <CardContent className="flex aspect-square items-center justify-center p-1">
+                                  <Image
+                                    src={image}
+                                    alt={`Imagen ${index + 1}`}
+                                    width={400}
+                                    height={400}
+                                    loading="lazy"
+                                    sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                                    className="w-full h-full object-cover rounded-lg"
+                                  />
+                                </CardContent>
+                              </Link>
+                            </Card>
+                          </CarouselItem>
+                        ) : null
+                      )
                     : null}
                 </CarouselContent>
                 <CarouselPrevious />

--- a/src/modules/maintenance/features/repairs/components/RepairSolicitudesTable/components/mechanicColumns.tsx
+++ b/src/modules/maintenance/features/repairs/components/RepairSolicitudesTable/components/mechanicColumns.tsx
@@ -36,6 +36,7 @@ function formatCalendar(dateStr: string): string {
   if (daysDiff < 0 && daysDiff > -7) return `${formatDateFns(date, 'EEEE', { locale: es })} a las ${formatDateFns(date, 'h:mm a')}`;
   return formatDateFns(date, 'dd/MM/yyyy');
 }
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -553,9 +554,13 @@ export const mechanicColums: ColumnDef<FormattedSolicitudesRepair[0]>[] = [
                           <Card className="">
                             <Link target="_blank" href={image || ''}>
                               <CardContent className="flex aspect-square items-center justify-center p-1">
-                                <img
+                                <Image
                                   src={image}
                                   alt={`Imagen ${index + 1}`}
+                                  width={400}
+                                  height={400}
+                                  loading="lazy"
+                                  sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                                   className="w-full h-full object-cover rounded-lg"
                                 />
                               </CardContent>
@@ -587,24 +592,30 @@ export const mechanicColums: ColumnDef<FormattedSolicitudesRepair[0]>[] = [
                   >
                     <CarouselContent className="p-2">
                       {imagesMechanic?.length
-                        ? imagesMechanic?.map((image, index) => (
-                            <CarouselItem
-                              key={crypto.randomUUID()}
-                              className="md:basis-1/2 lg:basis-1/3  overflow-hidden"
-                            >
-                              <Card className="">
-                                <Link target="_blank" href={image || ''}>
-                                  <CardContent className="flex aspect-square items-center justify-center p-1">
-                                    <img
-                                      src={image || ''}
-                                      alt={`Imagen ${index + 1}`}
-                                      className="w-full h-full object-cover rounded-lg"
-                                    />
-                                  </CardContent>
-                                </Link>
-                              </Card>
-                            </CarouselItem>
-                          ))
+                        ? imagesMechanic?.map((image, index) =>
+                            image ? (
+                              <CarouselItem
+                                key={crypto.randomUUID()}
+                                className="md:basis-1/2 lg:basis-1/3  overflow-hidden"
+                              >
+                                <Card className="">
+                                  <Link target="_blank" href={image}>
+                                    <CardContent className="flex aspect-square items-center justify-center p-1">
+                                      <Image
+                                        src={image}
+                                        alt={`Imagen ${index + 1}`}
+                                        width={400}
+                                        height={400}
+                                        loading="lazy"
+                                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                                        className="w-full h-full object-cover rounded-lg"
+                                      />
+                                    </CardContent>
+                                  </Link>
+                                </Card>
+                              </CarouselItem>
+                            ) : null
+                          )
                         : status !== row.original.state &&
                           Array.from({ length: 3 }).map((_, index) => (
                             <CarouselItem key={crypto.randomUUID()} className="md:basis-1/2 lg:basis-1/3 ">

--- a/src/shared/actions/notifications.ts
+++ b/src/shared/actions/notifications.ts
@@ -6,6 +6,8 @@ export const fetchNotificationsByCompany = async (companyId: string) => {
   try {
     const notifications = await prisma.notifications.findMany({
       where: { company_id: companyId },
+      orderBy: { created_at: 'desc' },
+      take: 50,
     });
 
     if (!notifications?.length) return [];

--- a/src/shared/components/layout/NavBar.tsx
+++ b/src/shared/components/layout/NavBar.tsx
@@ -9,6 +9,8 @@ import {
   DropdownMenuTrigger,
 } from '@/shared/components/ui/dropdown-menu';
 import { useLoggedUserStore } from '@/shared/store/loggedUser';
+import { startNotificationPolling, stopNotificationPolling } from '@/shared/store/uiStore';
+import { useEffect } from 'react';
 import {
   BellIcon,
   CheckCircledIcon,
@@ -64,6 +66,11 @@ export default function NavBar() {
   const actualUser = useLoggedUserStore((state) => state.profile);
   const notifications = useLoggedUserStore((state) => state.notifications);
   const markAllAsRead = useLoggedUserStore((state) => state.markAllAsRead);
+
+  useEffect(() => {
+    startNotificationPolling();
+    return () => stopNotificationPolling();
+  }, []);
 
   const handleCloseSidebar = () => {
     useLoggedUserStore.getState().toggleSidebar();

--- a/src/shared/lib/session.ts
+++ b/src/shared/lib/session.ts
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 import { cookies } from 'next/headers';
 import { prisma } from '@/shared/lib/prisma';
 import { fetchCurrentUser } from '@/shared/actions/auth';
@@ -23,10 +24,69 @@ const EMPTY_SESSION: Session = {
   sharedCompanies: [],
 };
 
+// Cacheado a nivel de request por user+companyId. Evita refetch en cada navegación
+// del layout (queries se quedaban fuera del scope de React.cache entre requests).
+// Invalidación implícita por cambio de companyId en cookie; revalidate de 60s para profile/companies.
+const buildSessionForUser = unstable_cache(
+  async (userId: string, userEmail: string, requestedCompanyId: string | undefined): Promise<Session> => {
+    const [profile, companies, sharedEntries] = await Promise.all([
+      prisma.profile.findUnique({
+        where: { id: userId },
+        select: { id: true, fullname: true, avatar: true, role: true, email: true },
+      }),
+      prisma.company.findMany({
+        where: { owner_id: userId },
+      }),
+      prisma.share_company_users.findMany({
+        where: { profile_id: userId },
+        include: { company: true },
+      }),
+    ]);
+
+    let activeCompanyId = requestedCompanyId;
+    if (!activeCompanyId) {
+      activeCompanyId = companies?.[0]?.id || sharedEntries?.[0]?.company_id || undefined;
+    }
+
+    let role: string | null = null;
+    let modules: string[] = [];
+
+    if (activeCompanyId) {
+      const isOwner = companies?.some((c: any) => c.id === activeCompanyId);
+      if (isOwner) {
+        role = 'owner';
+      } else {
+        const shared = sharedEntries?.find(
+          (e: any) => e.company_id === activeCompanyId || e.company?.id === activeCompanyId
+        );
+        role = shared?.role || null;
+        modules = (shared?.modules as string[]) || [];
+      }
+    }
+
+    const company = activeCompanyId
+      ? companies?.find((c: any) => c.id === activeCompanyId) ||
+        sharedEntries?.find((e: any) => e.company_id === activeCompanyId || e.company?.id === activeCompanyId)?.company ||
+        null
+      : null;
+
+    return {
+      user: { id: userId, email: userEmail },
+      profile,
+      company: company ? { id: company.id, company_name: company.company_name, owner_id: company.owner_id } : null,
+      role,
+      modules,
+      companies: companies || [],
+      sharedCompanies: sharedEntries || [],
+    };
+  },
+  ['session-data'],
+  { revalidate: 60, tags: ['session'] }
+);
+
 /**
  * Centralized session utility for server components and server actions.
- * Deduplicated per request via React.cache() — calling getSession() multiple
- * times in the same render cycle only executes the queries once.
+ * Deduplicated per request via React.cache(); cross-request via unstable_cache (60s).
  */
 export const getSession = cache(async (): Promise<Session> => {
   const user = await fetchCurrentUser();
@@ -35,58 +95,5 @@ export const getSession = cache(async (): Promise<Session> => {
   const cookiesStore = await cookies();
   const companyId = cookiesStore.get('actualComp')?.value;
 
-  // Run all independent queries in parallel
-  const [profile, companies, sharedEntries] = await Promise.all([
-    prisma.profile.findUnique({
-      where: { id: user.id },
-      select: { id: true, fullname: true, avatar: true, role: true, email: true },
-    }),
-    prisma.company.findMany({
-      where: { owner_id: user.id },
-    }),
-    prisma.share_company_users.findMany({
-      where: { profile_id: user.id },
-      include: { company: true },
-    }),
-  ]);
-
-  // Determine active company
-  let activeCompanyId = companyId;
-  if (!activeCompanyId) {
-    activeCompanyId = companies?.[0]?.id || sharedEntries?.[0]?.company_id || undefined;
-  }
-
-  // Determine role + modules for active company
-  let role: string | null = null;
-  let modules: string[] = [];
-
-  if (activeCompanyId) {
-    const isOwner = companies?.some((c: any) => c.id === activeCompanyId);
-    if (isOwner) {
-      role = 'owner';
-    } else {
-      const shared = sharedEntries?.find(
-        (e: any) => e.company_id === activeCompanyId || e.company?.id === activeCompanyId
-      );
-      role = shared?.role || null;
-      modules = (shared?.modules as string[]) || [];
-    }
-  }
-
-  // Get active company data
-  const company = activeCompanyId
-    ? companies?.find((c: any) => c.id === activeCompanyId) ||
-      sharedEntries?.find((e: any) => e.company_id === activeCompanyId || e.company?.id === activeCompanyId)?.company ||
-      null
-    : null;
-
-  return {
-    user: { id: user.id, email: user.email || '' },
-    profile,
-    company: company ? { id: company.id, company_name: company.company_name, owner_id: company.owner_id } : null,
-    role,
-    modules,
-    companies: companies || [],
-    sharedCompanies: sharedEntries || [],
-  };
+  return buildSessionForUser(user.id, user.email || '', companyId);
 });

--- a/src/shared/store/uiStore.ts
+++ b/src/shared/store/uiStore.ts
@@ -26,13 +26,8 @@ export const useUiStore = create<UiState>((set, get) => ({
     const companyId = useCompanyStore.getState().actualCompany?.id;
     if (!companyId) return;
 
-    const notifications = await fetchNotificationsByCompany(companyId);
-
-    const sorted = notifications?.sort(
-      (a: any, b: any) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-    ) as Notifications[];
-
-    set({ notifications: sorted });
+    const notifications = (await fetchNotificationsByCompany(companyId)) as Notifications[];
+    set({ notifications: notifications ?? [] });
   },
 
   markAllAsRead: async () => {
@@ -49,25 +44,63 @@ export const useUiStore = create<UiState>((set, get) => ({
   },
 }));
 
-// Polling replacement for real-time subscription (15s for notifications - more time-sensitive)
+// Polling de notificaciones — controlado por componentes que lo necesiten.
+// Se pausa con la pestaña en background para no consumir egress mientras nadie mira.
+const POLL_INTERVAL_MS = 60_000;
 let notificationPollInterval: NodeJS.Timeout | null = null;
+let visibilityListenerAttached = false;
+let activeSubscribers = 0;
 
-function startNotificationPolling() {
-  if (notificationPollInterval) return;
-  notificationPollInterval = setInterval(() => {
-    useUiStore.getState().allNotifications();
-  }, 15000);
+function tick() {
+  if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+  useUiStore.getState().allNotifications();
 }
 
-function stopNotificationPolling() {
+function ensureInterval() {
+  if (notificationPollInterval) return;
+  notificationPollInterval = setInterval(tick, POLL_INTERVAL_MS);
+}
+
+function clearPollInterval() {
   if (notificationPollInterval) {
     clearInterval(notificationPollInterval);
     notificationPollInterval = null;
   }
 }
 
-if (typeof window !== 'undefined') {
-  startNotificationPolling();
+function handleVisibilityChange() {
+  if (activeSubscribers === 0) return;
+  if (document.visibilityState === 'visible') {
+    ensureInterval();
+    tick();
+  } else {
+    clearPollInterval();
+  }
+}
+
+function startNotificationPolling() {
+  if (typeof window === 'undefined') return;
+  activeSubscribers += 1;
+  if (!visibilityListenerAttached) {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    visibilityListenerAttached = true;
+  }
+  if (document.visibilityState === 'visible') {
+    ensureInterval();
+    tick();
+  }
+}
+
+function stopNotificationPolling() {
+  if (typeof window === 'undefined') return;
+  activeSubscribers = Math.max(0, activeSubscribers - 1);
+  if (activeSubscribers === 0) {
+    clearPollInterval();
+    if (visibilityListenerAttached) {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      visibilityListenerAttached = false;
+    }
+  }
 }
 
 export { startNotificationPolling, stopNotificationPolling };


### PR DESCRIPTION
Plan integral para bajar el egress de 185 GB/mes (105% del Pro Plan) a < 100 GB/mes. Spike inició el 22-abr-2026 tras el merge de refactor/plan-maestro y el alta de mechanic_images en mantenimiento.

- uiStore + NavBar: el polling de notificaciones ya no se inicia solo al cargar el módulo. Ahora se monta/desmonta con el NavBar, respeta document.visibilityState (pausa con la pestaña en background) y subió de 15s a 60s. fetchNotificationsByCompany agrega take:50 + orderBy.
- mechanicColumns + RepairModal: <img src={getPublicUrl()}> migrado a next/image con width/height/sizes/loading=lazy. El optimizer de Next cachea las imágenes en CDN; se elimina la descarga directa desde Supabase Storage en cada vista de la tabla de reparaciones.
- next.config: remotePatterns con pathname /storage/v1/object/public/** y entradas para 127.0.0.1:54321 y localhost:54321 (Supabase local).
- companies/list: fetchCompaniesByOwner y fetchSharedCompaniesByProfile ya no hacen include de employees (el único consumer, companyStore, no los usa).
- /api/employees/diagrams: GET sin employee_id ahora filtra por actualComp en cookie/query (era un bug — traía diagramas de todas las empresas).
- /api/repair_solicitud: repairlogs con take:15 y orderBy desc para evitar nested includes sin tope.
- hse/documents: getDocuments con .limit(200) defensivo.
- session.ts: queries Prisma envueltas en unstable_cache con revalidate:60 y tag 'session'. cookies sigue formando parte del cache key vía argumento, así cambiar de empresa invalida correctamente.