### PR TITLE
fix: uploads directos a Supabase para evitar limite 4.5MB de Vercel

### DIFF
--- a/src/modules/documents/features/manage/actions.server.ts
+++ b/src/modules/documents/features/manage/actions.server.ts
@@ -1,6 +1,5 @@
 'use server';
 import { prisma } from '@/shared/lib/prisma';
-import { storageServer } from '@/shared/lib/storage-server';
 import { calculateNameOFDocument } from '@/shared/lib/utils';
 import { fetchCurrentUser } from '@/shared/actions/auth';
 
@@ -212,27 +211,34 @@ export const deleteDocumentEquipmentById = async (id: string) => {
   }
 };
 
-// -- Upload pending document --
+// -- Upload pending document (direct-to-storage pattern) --
+
+interface PreparePendingInput {
+  rowId: string;
+  kind: 'employee' | 'equipment';
+  fileName: string;
+  validityISO?: string | null;
+  period?: string | null;
+}
 
 /**
- * Upload de un documento pendiente desde el listado de Documentos.
- * Recibe el FormData con el archivo + datos opcionales (validity, period).
- * Calcula el path en storage, sube el archivo y actualiza la fila a estado 'presentado'.
+ * Paso 1: valida permisos y estado, calcula el path en storage.
+ * El cliente sube el archivo directo a Supabase Storage (sin pasar por Vercel).
  */
-export async function uploadPendingDocument(formData: FormData) {
+export async function preparePendingDocumentUpload(input: PreparePendingInput) {
   try {
-    const rowId = formData.get('rowId') as string;
-    const kind = formData.get('kind') as 'employee' | 'equipment';
-    const file = formData.get('file') as File | null;
-    const validityISO = (formData.get('validity') as string | null) || null;
-    const period = (formData.get('period') as string | null) || null;
-
-    if (!rowId || !kind || !file) {
-      return { ok: false, error: 'Faltan datos para cargar el documento' };
+    const { rowId, kind, fileName, validityISO, period } = input;
+    if (!rowId || !kind || !fileName) {
+      return { ok: false as const, error: 'Faltan datos para cargar el documento' };
     }
 
     const user = await fetchCurrentUser();
-    if (!user?.id) return { ok: false, error: 'No autenticado' };
+    if (!user?.id) return { ok: false as const, error: 'No autenticado' };
+
+    const fileExtension = fileName.split('.').pop() || 'bin';
+    const version = validityISO
+      ? new Date(validityISO).toISOString().slice(0, 10).split('-').reverse().join('-')
+      : period || 'v0';
 
     if (kind === 'employee') {
       const row = await prisma.documents_employees.findUnique({
@@ -243,52 +249,25 @@ export async function uploadPendingDocument(formData: FormData) {
         },
       });
       if (!row || !row.document_type || !row.employee || !row.employee.company) {
-        return { ok: false, error: 'Documento no encontrado' };
+        return { ok: false as const, error: 'Documento no encontrado' };
       }
       if (row.state !== 'pendiente') {
-        return { ok: false, error: 'El documento ya no está pendiente' };
+        return { ok: false as const, error: 'El documento ya no está pendiente' };
       }
 
       const company = row.employee.company;
-      const docType = row.document_type;
-      const appliesLabel = `${row.employee.firstname} ${row.employee.lastname}`;
-      const fileExtension = file.name.split('.').pop() || 'bin';
-      const version = validityISO
-        ? new Date(validityISO).toISOString().slice(0, 10).split('-').reverse().join('-')
-        : period || 'v0';
-
       const path = calculateNameOFDocument(
         company.company_name || '',
         company.company_cuit || '',
-        appliesLabel,
-        docType.name || '',
+        `${row.employee.firstname} ${row.employee.lastname}`,
+        row.document_type.name || '',
         version,
         fileExtension,
         'documentos-empleados'
       );
-
-      await storageServer.upload('document_files', path, file, {
-        cacheControl: '3600',
-        upsert: true,
-        contentType: file.type,
-      });
-
-      await prisma.documents_employees.update({
-        where: { id: rowId },
-        data: {
-          document_path: path,
-          state: 'presentado',
-          validity: validityISO,
-          period: period,
-          created_at: new Date(),
-          user_id: user.id,
-        },
-      });
-
-      return { ok: true };
+      return { ok: true as const, path, bucket: 'document_files' as const };
     }
 
-    // equipment
     const row = await prisma.documents_equipment.findUnique({
       where: { id: rowId },
       include: {
@@ -297,51 +276,69 @@ export async function uploadPendingDocument(formData: FormData) {
       },
     });
     if (!row || !row.document_type || !row.vehicle || !row.vehicle.company) {
-      return { ok: false, error: 'Documento no encontrado' };
+      return { ok: false as const, error: 'Documento no encontrado' };
     }
     if (row.state !== 'pendiente') {
-      return { ok: false, error: 'El documento ya no está pendiente' };
+      return { ok: false as const, error: 'El documento ya no está pendiente' };
     }
 
     const company = row.vehicle.company;
-    const docType = row.document_type;
     const appliesLabel = (row.vehicle.domain || row.vehicle.serie || row.vehicle.intern_number || '').toLowerCase();
-    const fileExtension = file.name.split('.').pop() || 'bin';
-    const version = validityISO
-      ? new Date(validityISO).toISOString().slice(0, 10).split('-').reverse().join('-')
-      : period || 'v0';
-
     const path = calculateNameOFDocument(
       company.company_name || '',
       company.company_cuit || '',
       appliesLabel,
-      docType.name || '',
+      row.document_type.name || '',
       version,
       fileExtension,
       'documentos-equipos'
     );
+    return { ok: true as const, path, bucket: 'document_files' as const };
+  } catch (error) {
+    console.error('Error preparing pending document:', error);
+    return { ok: false as const, error: error instanceof Error ? error.message : String(error) };
+  }
+}
 
-    await storageServer.upload('document_files', path, file, {
-      cacheControl: '3600',
-      upsert: true,
-      contentType: file.type,
-    });
+interface ConfirmPendingInput {
+  rowId: string;
+  kind: 'employee' | 'equipment';
+  path: string;
+  validityISO?: string | null;
+  period?: string | null;
+}
 
-    await prisma.documents_equipment.update({
-      where: { id: rowId },
-      data: {
-        document_path: path,
-        state: 'presentado',
-        validity: validityISO,
-        period: period,
-        created_at: new Date(),
-        user_id: user.id,
-      },
-    });
+/**
+ * Paso 2: confirma el upload y actualiza la fila a 'presentado'.
+ * Solo se llama después de que el cliente subió el archivo a storage.
+ */
+export async function confirmPendingDocumentUpload(input: ConfirmPendingInput) {
+  try {
+    const { rowId, kind, path, validityISO, period } = input;
+    if (!rowId || !kind || !path) {
+      return { ok: false, error: 'Faltan datos para confirmar la carga' };
+    }
 
+    const user = await fetchCurrentUser();
+    if (!user?.id) return { ok: false, error: 'No autenticado' };
+
+    const data = {
+      document_path: path,
+      state: 'presentado' as const,
+      validity: validityISO || null,
+      period: period || null,
+      created_at: new Date(),
+      user_id: user.id,
+    };
+
+    if (kind === 'employee') {
+      await prisma.documents_employees.update({ where: { id: rowId }, data });
+    } else {
+      await prisma.documents_equipment.update({ where: { id: rowId }, data });
+    }
     return { ok: true };
   } catch (error) {
-    console.error('Error uploading pending document:', error);
+    console.error('Error confirming pending document:', error);
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
 }

--- a/src/modules/documents/features/manage/components/UploadPendingDocumentDialog.tsx
+++ b/src/modules/documents/features/manage/components/UploadPendingDocumentDialog.tsx
@@ -16,7 +16,8 @@ import {
 } from '@/shared/components/ui/dialog';
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
-import { uploadPendingDocument } from '../actions.server';
+import { preparePendingDocumentUpload, confirmPendingDocumentUpload } from '../actions.server';
+import { storage } from '@/shared/lib/storage';
 
 interface Props {
   rowId: string;
@@ -57,18 +58,47 @@ export function UploadPendingDocumentDialog({
     }
 
     startTransition(async () => {
-      const fd = new FormData();
-      fd.set('rowId', rowId);
-      fd.set('kind', kind);
-      fd.set('file', file);
-      if (validity) fd.set('validity', new Date(validity).toISOString());
-      if (period) fd.set('period', period);
+      const validityISO = validity ? new Date(validity).toISOString() : null;
+      const periodValue = period || null;
 
-      const result = await uploadPendingDocument(fd);
-      if (!result.ok) {
-        toast.error(result.error || 'Error al cargar el documento');
+      const prep = await preparePendingDocumentUpload({
+        rowId,
+        kind,
+        fileName: file.name,
+        validityISO,
+        period: periodValue,
+      });
+      if (!prep.ok) {
+        toast.error(prep.error || 'Error al preparar la carga');
         return;
       }
+
+      try {
+        await storage.upload(prep.bucket, prep.path, file, {
+          cacheControl: '3600',
+          upsert: true,
+          contentType: file.type,
+        });
+      } catch (e: any) {
+        toast.error(e?.message || 'Error al subir el archivo');
+        return;
+      }
+
+      const confirmRes = await confirmPendingDocumentUpload({
+        rowId,
+        kind,
+        path: prep.path,
+        validityISO,
+        period: periodValue,
+      });
+      if (!confirmRes.ok) {
+        try {
+          await storage.remove(prep.bucket, [prep.path]);
+        } catch {}
+        toast.error(confirmRes.error || 'Error al confirmar la carga');
+        return;
+      }
+
       toast.success('Documento cargado correctamente');
       setOpen(false);
       setFile(null);

--- a/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
+++ b/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
@@ -9,7 +9,12 @@ import {
   PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES,
 } from '@/modules/purchasing/shared/validators';
 import { VOUCHER_TYPE_LABELS } from '@/modules/purchasing/shared/types';
-import { createPurchaseInvoice } from '@/modules/purchasing/features/invoices/list/actions.server';
+import {
+  createPurchaseInvoice,
+  preparePurchaseInvoiceAttachmentUpload,
+  confirmPurchaseInvoiceAttachmentUpload,
+} from '@/modules/purchasing/features/invoices/list/actions.server';
+import { storage } from '@/shared/lib/storage';
 import {
   getOrdersForInvoicing,
   getPurchaseOrderLinesForInvoicingBulk,
@@ -198,9 +203,37 @@ export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
         notes: values.notes,
         purchase_order_ids: values.purchase_order_ids || [],
         lines,
-        attachment: attachment || undefined,
       } as any);
       if (result.error) throw new Error(result.error);
+
+      if (attachment && result.data?.id) {
+        const invoiceId = result.data.id;
+        const prep = await preparePurchaseInvoiceAttachmentUpload({
+          invoiceId,
+          fileName: attachment.name,
+          mime: attachment.type,
+          size: attachment.size,
+        });
+        if (prep.ok) {
+          try {
+            await storage.upload(prep.bucket, prep.path, attachment, {
+              cacheControl: '3600',
+              upsert: false,
+              contentType: attachment.type,
+            });
+            const conf = await confirmPurchaseInvoiceAttachmentUpload({ invoiceId, path: prep.path });
+            if (conf.error) {
+              try { await storage.remove(prep.bucket, [prep.path]); } catch {}
+              toast.warning('Factura creada, pero falló la carga del adjunto. Reintentá desde el detalle.');
+            }
+          } catch {
+            toast.warning('Factura creada, pero falló la carga del adjunto. Reintentá desde el detalle.');
+          }
+        } else {
+          toast.warning(`Factura creada, pero el adjunto fue rechazado: ${prep.error}`);
+        }
+      }
+
       router.push('/dashboard/purchasing?tab=invoices'); router.refresh();
     }, { loading: 'Creando factura...', success: 'Factura creada', error: (e) => e?.message || 'Error' });
   };

--- a/src/modules/purchasing/features/invoices/list/actions.server.ts
+++ b/src/modules/purchasing/features/invoices/list/actions.server.ts
@@ -103,7 +103,6 @@ export async function createPurchaseInvoice(data: {
   purchase_order_id?: string;
   purchase_order_ids?: string[];
   lines: { product_id?: string; description: string; quantity: number; unit_cost: number; vat_rate: number; purchase_order_line_id?: string }[];
-  attachment?: File | null;
 }) {
   const { companyId } = await getActionContext();
   if (!companyId) throw new Error('No company selected');
@@ -161,20 +160,6 @@ export async function createPurchaseInvoice(data: {
       },
     });
 
-    // Adjunto opcional: subir y actualizar la factura recién creada.
-    if (data.attachment instanceof File && data.attachment.size > 0) {
-      try {
-        const uploadResult = await uploadInvoiceAttachment(invoice.id, companyId, data.attachment);
-        await prisma.purchase_invoices.update({
-          where: { id: invoice.id },
-          data: { document_url: uploadResult.publicUrl, document_key: uploadResult.path },
-        });
-      } catch (uploadErr) {
-        console.error('Error uploading invoice attachment:', uploadErr);
-        // No revertimos la factura; el usuario puede reintentar el adjunto desde el detalle.
-      }
-    }
-
     revalidatePath('/dashboard/purchasing');
     return {
       data: { ...invoice, subtotal: Number(invoice.subtotal), vat_amount: Number(invoice.vat_amount), other_taxes: Number(invoice.other_taxes), total: Number(invoice.total) },
@@ -202,69 +187,79 @@ function getExtensionFromMime(mime: string): string {
   return 'bin';
 }
 
-async function uploadInvoiceAttachment(invoiceId: string, companyId: string, file: File) {
-  if (!ALLOWED_MIME_SET.has(file.type)) {
-    throw new Error('Tipo de archivo no permitido. Solo se aceptan JPG, PNG o PDF.');
+/**
+ * Paso 1: valida la factura y el archivo, calcula el path en storage,
+ * y borra el adjunto previo si existía. El cliente sube el archivo directo a Supabase.
+ */
+export async function preparePurchaseInvoiceAttachmentUpload(input: {
+  invoiceId: string;
+  fileName: string;
+  mime: string;
+  size: number;
+}) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { ok: false as const, error: 'No company selected' };
+
+  const { invoiceId, fileName, mime, size } = input;
+  if (!invoiceId) return { ok: false as const, error: 'invoiceId requerido' };
+  if (!ALLOWED_MIME_SET.has(mime)) {
+    return { ok: false as const, error: 'Tipo de archivo no permitido. Solo se aceptan JPG, PNG o PDF.' };
   }
-  if (file.size > PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES) {
-    throw new Error('El archivo supera los 10 MB permitidos.');
+  if (size > PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES) {
+    return { ok: false as const, error: 'El archivo supera los 10 MB permitidos.' };
   }
 
-  const ext = getExtensionFromMime(file.type);
-  const path = `${companyId}/${invoiceId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
-
-  await storageServer.upload('purchase_invoices', path, file, {
-    cacheControl: '3600',
-    upsert: false,
-    contentType: file.type,
+  const invoice = await prisma.purchase_invoices.findFirst({
+    where: { id: invoiceId, company_id: companyId },
+    select: { id: true, document_key: true },
   });
+  if (!invoice) return { ok: false as const, error: 'Factura no encontrada' };
 
-  const publicUrl = await storageServer.getPublicUrl('purchase_invoices', path);
-  return { path, publicUrl };
+  if (invoice.document_key) {
+    try {
+      await storageServer.remove('purchase_invoices', [invoice.document_key]);
+    } catch (e) {
+      console.warn('Error removing previous attachment:', e);
+    }
+  }
+
+  const ext = getExtensionFromMime(mime) || (fileName.split('.').pop() || 'bin').toLowerCase();
+  const path = `${companyId}/${invoiceId}/${Date.now()}-${crypto.randomUUID()}.${ext}`;
+  return { ok: true as const, path, bucket: 'purchase_invoices' as const };
 }
 
-export async function attachPurchaseInvoiceDocument(formData: FormData) {
+/**
+ * Paso 2: confirma el upload del adjunto y actualiza la factura con la URL pública.
+ */
+export async function confirmPurchaseInvoiceAttachmentUpload(input: {
+  invoiceId: string;
+  path: string;
+}) {
   const { companyId } = await getActionContext();
   if (!companyId) return { error: 'No company selected' };
 
-  const invoiceId = formData.get('invoiceId');
-  const file = formData.get('file');
-
-  if (typeof invoiceId !== 'string' || !invoiceId) {
-    return { error: 'invoiceId requerido' };
-  }
-  if (!(file instanceof File) || file.size === 0) {
-    return { error: 'Archivo requerido' };
-  }
+  const { invoiceId, path } = input;
+  if (!invoiceId || !path) return { error: 'Datos incompletos' };
 
   try {
     const invoice = await prisma.purchase_invoices.findFirst({
       where: { id: invoiceId, company_id: companyId },
-      select: { id: true, document_key: true },
+      select: { id: true },
     });
     if (!invoice) return { error: 'Factura no encontrada' };
 
-    // Borrar adjunto previo (reemplazo).
-    if (invoice.document_key) {
-      try {
-        await storageServer.remove('purchase_invoices', [invoice.document_key]);
-      } catch (e) {
-        console.warn('Error removing previous attachment:', e);
-      }
-    }
-
-    const uploadResult = await uploadInvoiceAttachment(invoiceId, companyId, file);
+    const publicUrl = await storageServer.getPublicUrl('purchase_invoices', path);
 
     await prisma.purchase_invoices.update({
       where: { id: invoiceId },
-      data: { document_url: uploadResult.publicUrl, document_key: uploadResult.path },
+      data: { document_url: publicUrl, document_key: path },
     });
 
     revalidatePath('/dashboard/purchasing');
     revalidatePath(`/dashboard/purchasing/invoices/${invoiceId}`);
     return { error: null };
   } catch (error: any) {
-    console.error('Error attaching invoice document:', error);
+    console.error('Error confirming invoice attachment:', error);
     return { error: error?.message || String(error) };
   }
 }

--- a/src/modules/purchasing/features/invoices/list/components/InvoiceAttachmentSection.tsx
+++ b/src/modules/purchasing/features/invoices/list/components/InvoiceAttachmentSection.tsx
@@ -12,10 +12,12 @@ import {
   PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES,
 } from '@/modules/purchasing/shared/validators';
 import {
-  attachPurchaseInvoiceDocument,
+  preparePurchaseInvoiceAttachmentUpload,
+  confirmPurchaseInvoiceAttachmentUpload,
   getPurchaseInvoiceAttachmentSignedUrl,
   removePurchaseInvoiceDocument,
 } from '@/modules/purchasing/features/invoices/list/actions.server';
+import { storage } from '@/shared/lib/storage';
 
 interface Props {
   invoiceId: string;
@@ -62,18 +64,47 @@ export default function InvoiceAttachmentSection({ invoiceId, documentKey }: Pro
       return;
     }
     setBusy(true);
-    const formData = new FormData();
-    formData.append('invoiceId', invoiceId);
-    formData.append('file', file);
-    const res = await attachPurchaseInvoiceDocument(formData);
-    setBusy(false);
-    if (res.error) {
-      toast.error(res.error);
-    } else {
+    try {
+      const prep = await preparePurchaseInvoiceAttachmentUpload({
+        invoiceId,
+        fileName: file.name,
+        mime: file.type,
+        size: file.size,
+      });
+      if (!prep.ok) {
+        toast.error(prep.error);
+        return;
+      }
+
+      try {
+        await storage.upload(prep.bucket, prep.path, file, {
+          cacheControl: '3600',
+          upsert: false,
+          contentType: file.type,
+        });
+      } catch (uploadErr: any) {
+        toast.error(uploadErr?.message || 'Error al subir el archivo');
+        return;
+      }
+
+      const confirmRes = await confirmPurchaseInvoiceAttachmentUpload({
+        invoiceId,
+        path: prep.path,
+      });
+      if (confirmRes.error) {
+        try {
+          await storage.remove(prep.bucket, [prep.path]);
+        } catch {}
+        toast.error(confirmRes.error);
+        return;
+      }
+
       toast.success(documentKey ? 'Adjunto reemplazado' : 'Adjunto cargado');
       router.refresh();
+    } finally {
+      setBusy(false);
+      e.target.value = '';
     }
-    e.target.value = '';
   };
 
   const handleRemove = async () => {

--- a/src/modules/settings/features/pdf/actions.server.ts
+++ b/src/modules/settings/features/pdf/actions.server.ts
@@ -68,27 +68,27 @@ export async function upsertPdfSettings(input: {
 }
 
 /**
- * Sube la imagen de firma a storage y devuelve la URL pública.
+ * Paso 1: calcula el path de la firma. El cliente sube directo a Supabase.
  * Reusa el bucket `logo` con prefijo `pdf-signatures/{company_id}.{ext}`.
  */
-export async function uploadSignatureImage(formData: FormData) {
+export async function prepareSignatureUpload(input: { fileName: string }) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { ok: false as const, error: 'No company selected' };
+
+  const ext = input.fileName.split('.').pop()?.toLowerCase() || 'png';
+  const path = `pdf-signatures/${companyId}.${ext}`;
+  return { ok: true as const, path, bucket: 'logo' as const };
+}
+
+/**
+ * Paso 2: confirma el upload — actualiza pdf_settings con la URL pública.
+ */
+export async function confirmSignatureUpload(input: { path: string }) {
   const { companyId } = await getActionContext();
   if (!companyId) return { error: 'No company selected', url: null };
 
-  const file = formData.get('file') as File | null;
-  if (!file) return { error: 'Falta el archivo', url: null };
-
   try {
-    const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
-    const path = `pdf-signatures/${companyId}.${ext}`;
-
-    await storageServer.upload('logo', path, file, {
-      cacheControl: '3600',
-      upsert: true,
-      contentType: file.type || `image/${ext}`,
-    });
-
-    const url = await storageServer.getPublicUrl('logo', path);
+    const url = await storageServer.getPublicUrl('logo', input.path);
 
     await prisma.pdf_settings.upsert({
       where: { company_id: companyId },
@@ -102,7 +102,7 @@ export async function uploadSignatureImage(formData: FormData) {
     revalidatePath('/dashboard/settings');
     return { error: null, url };
   } catch (error) {
-    console.error('Error uploading signature:', error);
+    console.error('Error confirming signature:', error);
     return { error: error instanceof Error ? error.message : String(error), url: null };
   }
 }

--- a/src/modules/settings/features/pdf/components/PdfSettingsForm.tsx
+++ b/src/modules/settings/features/pdf/components/PdfSettingsForm.tsx
@@ -25,9 +25,11 @@ import {
 
 import {
   upsertPdfSettings,
-  uploadSignatureImage,
+  prepareSignatureUpload,
+  confirmSignatureUpload,
   removeSignatureImage,
 } from '../actions.server';
+import { storage } from '@/shared/lib/storage';
 import { SIGNABLE_PDF_KEYS, type PdfSettingsData } from '../types';
 
 interface Props {
@@ -71,11 +73,29 @@ export function PdfSettingsForm({ initial }: Props) {
       return;
     }
     startUpload(async () => {
-      const fd = new FormData();
-      fd.set('file', file);
-      const result = await uploadSignatureImage(fd);
+      const prep = await prepareSignatureUpload({ fileName: file.name });
+      if (!prep.ok) {
+        toast.error('Error al preparar la carga', { description: prep.error });
+        return;
+      }
+
+      try {
+        await storage.upload(prep.bucket, prep.path, file, {
+          cacheControl: '3600',
+          upsert: true,
+          contentType: file.type || 'image/png',
+        });
+      } catch (e: any) {
+        toast.error('Error al subir la firma', { description: e?.message });
+        return;
+      }
+
+      const result = await confirmSignatureUpload({ path: prep.path });
       if (result.error) {
-        toast.error('Error al subir la firma', { description: result.error });
+        try {
+          await storage.remove(prep.bucket, [prep.path]);
+        } catch {}
+        toast.error('Error al confirmar la firma', { description: result.error });
         return;
       }
       toast.success('Firma cargada');


### PR DESCRIPTION
Refactor de Server Actions que recibian File via FormData (uploadPendingDocument, uploadSignatureImage, attachPurchaseInvoiceDocument) al patron prepare/confirm: el cliente sube el archivo directo a Supabase Storage y el SA solo valida y actualiza la DB. Incluye rollback del blob si falla el confirm.