### PR TITLE
fix(treasury): cash_movements.payment_order_id faltante + filtro de c…

### DIFF
--- a/src/modules/treasury/features/cash-registers/actions.server.ts
+++ b/src/modules/treasury/features/cash-registers/actions.server.ts
@@ -71,10 +71,26 @@ export async function getCashRegisterFacets(): Promise<
 export async function getAllCashRegisters() {
   const { companyId } = await getActionContext();
   if (!companyId) return [];
-  return prisma.cash_registers.findMany({
+
+  const registers = await prisma.cash_registers.findMany({
     where: { company_id: companyId, status: 'ACTIVE' },
     orderBy: { code: 'asc' },
   });
+
+  if (registers.length === 0) return [];
+
+  // Cajas con sesión abierta (para que la UI pueda deshabilitar las que no).
+  const openSessions = await prisma.cash_register_sessions.findMany({
+    where: {
+      company_id: companyId,
+      cash_register_id: { in: registers.map((r) => r.id) },
+      status: 'OPEN',
+    },
+    select: { cash_register_id: true },
+  });
+  const openSet = new Set(openSessions.map((s) => s.cash_register_id));
+
+  return registers.map((r) => ({ ...r, has_open_session: openSet.has(r.id) }));
 }
 
 export async function getCashRegisterById(id: string) {

--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -458,14 +458,26 @@ export async function confirmPaymentOrder(id: string) {
           return { error: 'Hay un pago en efectivo sin caja asignada' };
         }
         const openSession = await prisma.cash_register_sessions.findFirst({
-          where: { cash_register_id: p.cash_register_id, status: 'OPEN' },
+          where: {
+            cash_register_id: p.cash_register_id,
+            company_id: companyId,
+            status: 'OPEN',
+          },
           select: { id: true },
         });
         if (!openSession) {
           const register = await prisma.cash_registers.findUnique({
             where: { id: p.cash_register_id },
-            select: { code: true },
+            select: { code: true, company_id: true },
           });
+          // Diagnóstico: si la caja existe pero pertenece a otra empresa, el
+          // cash_register_id que llegó del payment es inconsistente con la
+          // sesión activa. Tirar mensaje específico.
+          if (register && register.company_id !== companyId) {
+            return {
+              error: `La caja ${register.code} pertenece a otra empresa. Recargá la página y volvé a seleccionar la caja.`,
+            };
+          }
           return {
             error: `La caja ${register?.code ?? ''} no tiene sesión abierta. Abrila antes de confirmar.`,
           };

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
@@ -52,6 +52,7 @@ interface CashRegisterOpt {
   id: string;
   code: string;
   name: string;
+  has_open_session: boolean;
 }
 
 interface BankAccountOpt {
@@ -716,12 +717,23 @@ export function NewPaymentOrderForm({
                       </SelectTrigger>
                       <SelectContent>
                         {cashRegisters.map((c) => (
-                          <SelectItem key={c.id} value={c.id}>
+                          <SelectItem
+                            key={c.id}
+                            value={c.id}
+                            disabled={!c.has_open_session}
+                          >
                             {c.code} — {c.name}
+                            {!c.has_open_session && ' (sin sesión abierta)'}
                           </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
+                    {cashRegisters.every((c) => !c.has_open_session) && (
+                      <p className="text-xs text-amber-600">
+                        Ninguna caja tiene sesión abierta. Abrí una desde Tesorería → Cajas
+                        antes de confirmar el pago en efectivo.
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderShell.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderShell.tsx
@@ -26,6 +26,7 @@ export async function NewPaymentOrderShell({ initialData }: ShellProps = {}) {
         id: c.id,
         code: c.code,
         name: c.name,
+        has_open_session: c.has_open_session,
       }))}
       bankAccounts={bankAccounts.map((a) => ({
         id: a.id,

--- a/src/modules/treasury/features/sessions/actions.server.ts
+++ b/src/modules/treasury/features/sessions/actions.server.ts
@@ -108,6 +108,8 @@ export async function openSession(data: OpenSessionFormData) {
     });
 
     revalidatePath(`/dashboard/treasury/cash-registers/${parsed.data.cash_register_id}`);
+    // También invalida la lista de cajas y el form de OP (que filtran por has_open_session).
+    revalidatePath('/dashboard/treasury', 'layout');
     return { data: session, error: null };
   } catch (error) {
     console.error('Error opening session:', error);
@@ -178,6 +180,7 @@ export async function closeSession(data: CloseSessionFormData) {
     });
 
     revalidatePath(`/dashboard/treasury/cash-registers/${session.cash_register_id}`);
+    revalidatePath('/dashboard/treasury', 'layout');
     return { data: updated, error: null };
   } catch (error) {
     console.error('Error closing session:', error);

--- a/supabase/migrations/20260506135357_fix_add_payment_order_id_to_cash_movements.sql
+++ b/supabase/migrations/20260506135357_fix_add_payment_order_id_to_cash_movements.sql
@@ -1,0 +1,34 @@
+-- ================================================================
+-- FIX: cash_movements.payment_order_id no existía en DB
+-- ================================================================
+-- La migración 20260505123008_add_payment_order_id_to_cash_movements.sql
+-- fue commiteada como archivo vacío (0 bytes), por lo que aplicó como
+-- noop. El schema Prisma sí incluye el campo, lo que rompe inserts en
+-- cash_movements ("column (not available) does not exist").
+--
+-- Esta migración es idempotente: usa IF NOT EXISTS para que sea segura
+-- correr tanto en entornos donde la columna nunca se creó como en los
+-- que pudieran tenerla por algún hotfix manual.
+-- ================================================================
+
+BEGIN;
+
+ALTER TABLE "cash_movements"
+  ADD COLUMN IF NOT EXISTS "payment_order_id" uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cash_movements_payment_order_id_fkey'
+  ) THEN
+    ALTER TABLE "cash_movements"
+      ADD CONSTRAINT "cash_movements_payment_order_id_fkey"
+      FOREIGN KEY ("payment_order_id") REFERENCES "payment_orders"("id")
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "cash_movements_payment_order_id_idx"
+  ON "cash_movements" ("payment_order_id");
+
+COMMIT;


### PR DESCRIPTION
…ajas en OP

La migración 20260505123008 fue commiteada vacía (0 bytes) en COD-572: el schema Prisma incluye payment_order_id pero la DB nunca tuvo la columna, lo que rompía abrir sesión de caja ("column (not available) does not exist").

- Migración fix idempotente que agrega la columna, FK e índice.
- Form de OP filtra cajas: deshabilita las que no tienen sesión abierta y muestra banner si ninguna está abierta.
- openSession/closeSession revalidan el árbol de tesorería para refrescar el form de OP cuando se abre/cierra desde otra pestaña.
- confirmPaymentOrder filtra sesión también por company_id y da un mensaje específico si la caja pertenece a otra empresa.