### PR TITLE
feat(treasury): sistema de retenciones y percepciones + export Excel

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -256,6 +256,7 @@ export type Database = {
           date: string
           description: string
           id: string
+          payment_order_id: string | null
           purchase_invoice_id: string | null
           reference: string | null
           session_id: string
@@ -271,6 +272,7 @@ export type Database = {
           date?: string
           description: string
           id?: string
+          payment_order_id?: string | null
           purchase_invoice_id?: string | null
           reference?: string | null
           session_id: string
@@ -286,6 +288,7 @@ export type Database = {
           date?: string
           description?: string
           id?: string
+          payment_order_id?: string | null
           purchase_invoice_id?: string | null
           reference?: string | null
           session_id?: string
@@ -305,6 +308,13 @@ export type Database = {
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cash_movements_payment_order_id_fkey"
+            columns: ["payment_order_id"]
+            isOneToOne: false
+            referencedRelation: "payment_orders"
             referencedColumns: ["id"]
           },
           {
@@ -2923,6 +2933,60 @@ export type Database = {
           },
         ]
       }
+      payment_order_retentions: {
+        Row: {
+          amount: number
+          base_amount: number
+          certificate_number: string | null
+          certificate_url: string | null
+          created_at: string
+          id: string
+          notes: string | null
+          payment_order_id: string
+          rate: number
+          tax_type_id: string
+        }
+        Insert: {
+          amount: number
+          base_amount: number
+          certificate_number?: string | null
+          certificate_url?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          payment_order_id: string
+          rate: number
+          tax_type_id: string
+        }
+        Update: {
+          amount?: number
+          base_amount?: number
+          certificate_number?: string | null
+          certificate_url?: string | null
+          created_at?: string
+          id?: string
+          notes?: string | null
+          payment_order_id?: string
+          rate?: number
+          tax_type_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "payment_order_retentions_payment_order_id_fkey"
+            columns: ["payment_order_id"]
+            isOneToOne: false
+            referencedRelation: "payment_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "payment_order_retentions_tax_type_id_fkey"
+            columns: ["tax_type_id"]
+            isOneToOne: false
+            referencedRelation: "tax_types"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       payment_orders: {
         Row: {
           company_id: string
@@ -2935,10 +2999,12 @@ export type Database = {
           document_url: string | null
           full_number: string
           id: string
+          net_to_pay: number | null
           notes: string | null
           number: number
           paid_at: string | null
           paid_by: string | null
+          retentions_total: number
           scheduled_payment_date: string | null
           status: Database["public"]["Enums"]["payment_order_status"]
           supplier_id: string | null
@@ -2956,10 +3022,12 @@ export type Database = {
           document_url?: string | null
           full_number: string
           id?: string
+          net_to_pay?: number | null
           notes?: string | null
           number: number
           paid_at?: string | null
           paid_by?: string | null
+          retentions_total?: number
           scheduled_payment_date?: string | null
           status?: Database["public"]["Enums"]["payment_order_status"]
           supplier_id?: string | null
@@ -2977,10 +3045,12 @@ export type Database = {
           document_url?: string | null
           full_number?: string
           id?: string
+          net_to_pay?: number | null
           notes?: string | null
           number?: number
           paid_at?: string | null
           paid_by?: string | null
+          retentions_total?: number
           scheduled_payment_date?: string | null
           status?: Database["public"]["Enums"]["payment_order_status"]
           supplier_id?: string | null
@@ -3318,6 +3388,54 @@ export type Database = {
             columns: ["purchase_order_line_id"]
             isOneToOne: false
             referencedRelation: "purchase_order_lines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      purchase_invoice_perceptions: {
+        Row: {
+          amount: number
+          base_amount: number
+          created_at: string
+          id: string
+          invoice_id: string
+          notes: string | null
+          rate: number
+          tax_type_id: string
+        }
+        Insert: {
+          amount: number
+          base_amount: number
+          created_at?: string
+          id?: string
+          invoice_id: string
+          notes?: string | null
+          rate: number
+          tax_type_id: string
+        }
+        Update: {
+          amount?: number
+          base_amount?: number
+          created_at?: string
+          id?: string
+          invoice_id?: string
+          notes?: string | null
+          rate?: number
+          tax_type_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "purchase_invoice_perceptions_invoice_id_fkey"
+            columns: ["invoice_id"]
+            isOneToOne: false
+            referencedRelation: "purchase_invoices"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchase_invoice_perceptions_tax_type_id_fkey"
+            columns: ["tax_type_id"]
+            isOneToOne: false
+            referencedRelation: "tax_types"
             referencedColumns: ["id"]
           },
         ]
@@ -3937,6 +4055,42 @@ export type Database = {
           },
         ]
       }
+      retention_certificate_sequences: {
+        Row: {
+          company_id: string
+          last_number: number
+          tax_type_id: string
+          updated_at: string
+        }
+        Insert: {
+          company_id: string
+          last_number?: number
+          tax_type_id: string
+          updated_at?: string
+        }
+        Update: {
+          company_id?: string
+          last_number?: number
+          tax_type_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "retention_certificate_sequences_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "retention_certificate_sequences_tax_type_id_fkey"
+            columns: ["tax_type_id"]
+            isOneToOne: false
+            referencedRelation: "tax_types"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       role_permissions: {
         Row: {
           created_at: string
@@ -4394,6 +4548,65 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "suppliers_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tax_types: {
+        Row: {
+          calculation_base: Database["public"]["Enums"]["tax_calculation_base"]
+          code: string
+          company_id: string
+          created_at: string
+          default_rate: number
+          id: string
+          is_active: boolean
+          jurisdiction: string | null
+          kind: Database["public"]["Enums"]["tax_kind"]
+          min_taxable_amount: number | null
+          name: string
+          notes: string | null
+          scope: Database["public"]["Enums"]["tax_scope"]
+          updated_at: string
+        }
+        Insert: {
+          calculation_base?: Database["public"]["Enums"]["tax_calculation_base"]
+          code: string
+          company_id: string
+          created_at?: string
+          default_rate?: number
+          id?: string
+          is_active?: boolean
+          jurisdiction?: string | null
+          kind: Database["public"]["Enums"]["tax_kind"]
+          min_taxable_amount?: number | null
+          name: string
+          notes?: string | null
+          scope?: Database["public"]["Enums"]["tax_scope"]
+          updated_at?: string
+        }
+        Update: {
+          calculation_base?: Database["public"]["Enums"]["tax_calculation_base"]
+          code?: string
+          company_id?: string
+          created_at?: string
+          default_rate?: number
+          id?: string
+          is_active?: boolean
+          jurisdiction?: string | null
+          kind?: Database["public"]["Enums"]["tax_kind"]
+          min_taxable_amount?: number | null
+          name?: string
+          notes?: string | null
+          scope?: Database["public"]["Enums"]["tax_scope"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tax_types_company_id_fkey"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "company"
@@ -5337,6 +5550,9 @@ export type Database = {
         | "EXENTO"
         | "NO_RESPONSABLE"
         | "CONSUMIDOR_FINAL"
+      tax_calculation_base: "NET" | "TOTAL" | "VAT"
+      tax_kind: "RETENTION" | "PERCEPTION"
+      tax_scope: "NATIONAL" | "PROVINCIAL" | "MUNICIPAL"
       type_of_maintenance_ENUM: "Correctivo" | "Preventivo"
       voucher_type:
         | "FACTURA_A"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -394,6 +394,10 @@ model company {
   // Roles y permisos
   roles      roles[]
   user_roles user_roles[]
+
+  // Retenciones y percepciones
+  tax_types                       tax_types[]
+  retention_certificate_sequences retention_certificate_sequences[]
 }
 
 model pdf_settings {
@@ -1914,16 +1918,17 @@ model purchase_invoices {
   created_at          DateTime                          @default(now()) @db.Timestamptz
   updated_at          DateTime                          @default(now()) @updatedAt @db.Timestamptz
 
-  company             company                       @relation(fields: [company_id], references: [id])
-  supplier            suppliers                     @relation(fields: [supplier_id], references: [id])
-  purchase_order      purchase_orders?              @relation(fields: [purchase_order_id], references: [id])
-  original_invoice    purchase_invoices?            @relation("purchase_invoice_credit_notes", fields: [original_invoice_id], references: [id])
-  credit_notes        purchase_invoices[]           @relation("purchase_invoice_credit_notes")
+  company             company                        @relation(fields: [company_id], references: [id])
+  supplier            suppliers                      @relation(fields: [supplier_id], references: [id])
+  purchase_order      purchase_orders?               @relation(fields: [purchase_order_id], references: [id])
+  original_invoice    purchase_invoices?             @relation("purchase_invoice_credit_notes", fields: [original_invoice_id], references: [id])
+  credit_notes        purchase_invoices[]            @relation("purchase_invoice_credit_notes")
   lines               purchase_invoice_lines[]
   installments        purchase_order_installments[]
   receiving_notes     receiving_notes[]
   payment_order_items payment_order_items[]
   cash_movements      cash_movements[]
+  perceptions         purchase_invoice_perceptions[]
 
   @@unique([company_id, supplier_id, full_number])
   @@index([purchase_order_id])
@@ -2275,6 +2280,8 @@ model payment_orders {
   full_number            String
   date                   DateTime             @db.Timestamptz
   total_amount           Decimal              @db.Decimal(15, 2)
+  retentions_total       Decimal              @default(0) @db.Decimal(15, 2)
+  net_to_pay             Decimal?             @db.Decimal(15, 2)
   notes                  String?
   status                 payment_order_status @default(DRAFT)
   document_url           String?
@@ -2288,16 +2295,110 @@ model payment_orders {
   created_at             DateTime             @default(now()) @db.Timestamptz
   updated_at             DateTime             @default(now()) @updatedAt @db.Timestamptz
 
-  company        company                  @relation(fields: [company_id], references: [id], onDelete: Cascade)
-  supplier       suppliers?               @relation(fields: [supplier_id], references: [id])
+  company        company                    @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  supplier       suppliers?                 @relation(fields: [supplier_id], references: [id])
   items          payment_order_items[]
   payments       payment_order_payments[]
   bank_movements bank_movements[]
   cash_movements cash_movements[]
+  retentions     payment_order_retentions[]
 
   @@unique([company_id, number])
   @@index([company_id, status])
   @@index([supplier_id, status])
+}
+
+// ============================================================
+// RETENCIONES Y PERCEPCIONES (Fase 1)
+// ============================================================
+
+enum tax_kind {
+  RETENTION
+  PERCEPTION
+}
+
+enum tax_scope {
+  NATIONAL
+  PROVINCIAL
+  MUNICIPAL
+}
+
+enum tax_calculation_base {
+  NET
+  TOTAL
+  VAT
+}
+
+model tax_types {
+  id                 String               @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  company_id         String               @db.Uuid
+  code               String
+  name               String
+  kind               tax_kind
+  scope              tax_scope            @default(NATIONAL)
+  jurisdiction       String?
+  calculation_base   tax_calculation_base @default(NET)
+  default_rate       Decimal              @default(0) @db.Decimal(8, 4)
+  min_taxable_amount Decimal?             @db.Decimal(15, 2)
+  is_active          Boolean              @default(true)
+  notes              String?
+  created_at         DateTime             @default(now()) @db.Timestamptz
+  updated_at         DateTime             @default(now()) @updatedAt @db.Timestamptz
+
+  company             company                          @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  invoice_perceptions purchase_invoice_perceptions[]
+  order_retentions    payment_order_retentions[]
+  certificate_seq     retention_certificate_sequences[]
+
+  @@unique([company_id, code], map: "tax_types_company_code_unique")
+}
+
+model purchase_invoice_perceptions {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  invoice_id  String   @db.Uuid
+  tax_type_id String   @db.Uuid
+  base_amount Decimal  @db.Decimal(15, 2)
+  rate        Decimal  @db.Decimal(8, 4)
+  amount      Decimal  @db.Decimal(15, 2)
+  notes       String?
+  created_at  DateTime @default(now()) @db.Timestamptz
+
+  invoice  purchase_invoices @relation(fields: [invoice_id], references: [id], onDelete: Cascade)
+  tax_type tax_types         @relation(fields: [tax_type_id], references: [id])
+
+  @@index([invoice_id])
+  @@index([tax_type_id])
+}
+
+model payment_order_retentions {
+  id                 String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  payment_order_id   String   @db.Uuid
+  tax_type_id        String   @db.Uuid
+  base_amount        Decimal  @db.Decimal(15, 2)
+  rate               Decimal  @db.Decimal(8, 4)
+  amount             Decimal  @db.Decimal(15, 2)
+  certificate_number String?
+  certificate_url    String?
+  notes              String?
+  created_at         DateTime @default(now()) @db.Timestamptz
+
+  payment_order payment_orders @relation(fields: [payment_order_id], references: [id], onDelete: Cascade)
+  tax_type      tax_types      @relation(fields: [tax_type_id], references: [id])
+
+  @@index([payment_order_id])
+  @@index([tax_type_id])
+}
+
+model retention_certificate_sequences {
+  company_id  String   @db.Uuid
+  tax_type_id String   @db.Uuid
+  last_number Int      @default(0)
+  updated_at  DateTime @default(now()) @db.Timestamptz
+
+  company  company   @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  tax_type tax_types @relation(fields: [tax_type_id], references: [id], onDelete: Cascade)
+
+  @@id([company_id, tax_type_id])
 }
 
 model payment_order_items {

--- a/src/app/api/payment-orders/[id]/pdf/route.ts
+++ b/src/app/api/payment-orders/[id]/pdf/route.ts
@@ -72,6 +72,12 @@ export async function GET(
             },
           },
         },
+        retentions: {
+          include: {
+            tax_type: { select: { name: true, jurisdiction: true } },
+          },
+          orderBy: { created_at: 'asc' },
+        },
       },
     });
     if (!order) {
@@ -151,8 +157,21 @@ export async function GET(
         amount: Number(p.amount),
         destination: mapPaymentDestinationForPDF(p.supplier_payment_method),
       })),
+      retentions: order.retentions.map((r) => ({
+        name: r.tax_type.name,
+        jurisdiction: r.tax_type.jurisdiction,
+        baseAmount: Number(r.base_amount),
+        rate: Number(r.rate),
+        amount: Number(r.amount),
+        certificateNumber: r.certificate_number,
+      })),
       totalAmount,
-      amountInWords: amountToSpanishWords(totalAmount),
+      retentionsTotal: Number(order.retentions_total),
+      netToPay:
+        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount,
+      amountInWords: amountToSpanishWords(
+        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount
+      ),
       pdfSettings,
     };
 

--- a/src/app/api/retention-certificates/[id]/pdf/route.ts
+++ b/src/app/api/retention-certificates/[id]/pdf/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/retention-certificates/:id/pdf
+ * Devuelve el PDF del comprobante de retención asociado a una línea
+ * payment_order_retentions ya numerada (OP confirmada).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import {
+  buildRetentionCertificateData,
+  generateRetentionCertificatePDF,
+  getRetentionCertificateFileName,
+} from '@/modules/treasury/features/payment-orders/shared/retention-certificate';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  try {
+    const cookieStore = await cookies();
+    const companyId = cookieStore.get('actualComp')?.value;
+    if (!companyId) {
+      return NextResponse.json({ error: 'No hay empresa activa' }, { status: 400 });
+    }
+
+    const data = await buildRetentionCertificateData(id, companyId);
+    if (!data) {
+      return NextResponse.json(
+        { error: 'Comprobante no encontrado o aún no numerado' },
+        { status: 404 }
+      );
+    }
+
+    const pdfBuffer = await generateRetentionCertificatePDF(data);
+    const fileName = getRetentionCertificateFileName(data);
+
+    return new NextResponse(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${fileName}"`,
+        'Content-Length': pdfBuffer.length.toString(),
+      },
+    });
+  } catch (error) {
+    console.error('Error generando comprobante de retención:', error);
+    return NextResponse.json({ error: 'Error al generar el PDF' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/purchasing/invoices/[id]/page.tsx
+++ b/src/app/dashboard/purchasing/invoices/[id]/page.tsx
@@ -35,6 +35,12 @@ export default async function InvoiceDetailPage({ params }: { params: Promise<{ 
           },
         },
       },
+      perceptions: {
+        include: {
+          tax_type: { select: { code: true, name: true, jurisdiction: true } },
+        },
+        orderBy: { created_at: 'asc' },
+      },
     },
   });
 
@@ -160,10 +166,53 @@ export default async function InvoiceDetailPage({ params }: { params: Promise<{ 
           <div className="flex justify-end text-sm space-x-8">
             <div>Subtotal: <span className="font-mono font-medium">${Number(invoice.subtotal).toFixed(2)}</span></div>
             <div>IVA: <span className="font-mono font-medium">${Number(invoice.vat_amount).toFixed(2)}</span></div>
+            {Number(invoice.other_taxes) > 0 && (
+              <div>Percepciones: <span className="font-mono font-medium">${Number(invoice.other_taxes).toFixed(2)}</span></div>
+            )}
             <div className="text-lg font-bold">Total: <span className="font-mono">${Number(invoice.total).toFixed(2)}</span></div>
           </div>
         </CardContent>
       </Card>
+
+      {invoice.perceptions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Percepciones</CardTitle>
+            <CardDescription>
+              Cargos adicionales informados por el proveedor (suman al total).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Concepto</TableHead>
+                  <TableHead className="text-right">Base</TableHead>
+                  <TableHead className="text-right">Alícuota</TableHead>
+                  <TableHead className="text-right">Monto</TableHead>
+                  <TableHead>Notas</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {invoice.perceptions.map((p) => (
+                  <TableRow key={p.id}>
+                    <TableCell>
+                      <div className="font-medium">{p.tax_type.name}</div>
+                      {p.tax_type.jurisdiction && (
+                        <div className="text-xs text-muted-foreground">{p.tax_type.jurisdiction}</div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">${Number(p.base_amount).toFixed(2)}</TableCell>
+                    <TableCell className="text-right font-mono">{Number(p.rate)}%</TableCell>
+                    <TableCell className="text-right font-mono font-medium">${Number(p.amount).toFixed(2)}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">{p.notes ?? '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
 
       {linkedPaymentOrders.length > 0 && (
         <Card>

--- a/src/app/dashboard/purchasing/invoices/new/page.tsx
+++ b/src/app/dashboard/purchasing/invoices/new/page.tsx
@@ -1,11 +1,13 @@
 import { getSuppliersByCompany } from '@/modules/suppliers/features/list/actions.server';
 import { getProductsByCompany } from '@/modules/products/features/list/actions.server';
 import PurchaseInvoiceForm from '@/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm';
+import { listTaxTypes } from '@/modules/settings/features/taxes/actions.server';
 
 export default async function NewInvoicePage() {
-  const [suppliers, products] = await Promise.all([
+  const [suppliers, products, perceptionTypes] = await Promise.all([
     getSuppliersByCompany(),
     getProductsByCompany(),
+    listTaxTypes('PERCEPTION'),
   ]);
 
   return (
@@ -14,6 +16,7 @@ export default async function NewInvoicePage() {
       <PurchaseInvoiceForm
         suppliers={suppliers as any}
         products={products.map((p) => ({ ...p, cost_price: Number(p.cost_price), vat_rate: Number(p.vat_rate) }))}
+        perceptionTypes={perceptionTypes.filter((t) => t.is_active)}
       />
     </div>
   );

--- a/src/app/dashboard/treasury/page.tsx
+++ b/src/app/dashboard/treasury/page.tsx
@@ -11,10 +11,21 @@ import CashRegistersList from '@/modules/treasury/features/cash-registers/compon
 import BankAccountsList from '@/modules/treasury/features/bank-accounts/components/BankAccountsList';
 import ChecksList from '@/modules/treasury/features/checks/components/ChecksList';
 import PaymentOrdersList from '@/modules/treasury/features/payment-orders/components/PaymentOrdersList';
-import Link from 'next/link';
-import { Button } from '@/shared/components/ui/button';
+import RetentionsView from '@/modules/treasury/features/retentions/components/RetentionsView';
+import {
+  listPendingInvoices,
+  getSuppliersWithPendingInvoices,
+  PendingBalancesView,
+} from '@/modules/treasury/features/pending-balances';
 
-const VALID_TABS = ['cash-registers', 'bank-accounts', 'checks', 'payment-orders'] as const;
+const VALID_TABS = [
+  'cash-registers',
+  'bank-accounts',
+  'checks',
+  'payment-orders',
+  'retentions',
+  'pending-balances',
+] as const;
 type TreasuryTab = (typeof VALID_TABS)[number];
 
 export default async function TreasuryPage({
@@ -26,6 +37,10 @@ export default async function TreasuryPage({
     supplier?: string;
     from?: string;
     to?: string;
+    op_status?: string;
+    search?: string;
+    page?: string;
+    [key: string]: string | string[] | undefined;
   }>;
 }) {
   const resolved = await searchParams;
@@ -42,17 +57,14 @@ export default async function TreasuryPage({
   return (
     <div className="p-6">
       <UrlTabs value={tab} paramName="tab" baseUrl="/dashboard/treasury">
-        <div className="flex items-center justify-between">
-          <UrlTabsList>
-            <UrlTabsTrigger value="cash-registers">Cajas</UrlTabsTrigger>
-            <UrlTabsTrigger value="bank-accounts">Cuentas bancarias</UrlTabsTrigger>
-            <UrlTabsTrigger value="checks">Cheques</UrlTabsTrigger>
-            <UrlTabsTrigger value="payment-orders">Órdenes de pago</UrlTabsTrigger>
-          </UrlTabsList>
-          <Button asChild variant="outline" size="sm">
-            <Link href="/dashboard/treasury/pending-balances">Saldos Pendientes</Link>
-          </Button>
-        </div>
+        <UrlTabsList>
+          <UrlTabsTrigger value="cash-registers">Cajas</UrlTabsTrigger>
+          <UrlTabsTrigger value="bank-accounts">Cuentas bancarias</UrlTabsTrigger>
+          <UrlTabsTrigger value="checks">Cheques</UrlTabsTrigger>
+          <UrlTabsTrigger value="payment-orders">Órdenes de pago</UrlTabsTrigger>
+          <UrlTabsTrigger value="retentions">Retenciones</UrlTabsTrigger>
+          <UrlTabsTrigger value="pending-balances">Saldos pendientes</UrlTabsTrigger>
+        </UrlTabsList>
 
         <UrlTabsContent value="cash-registers">
           <Card>
@@ -117,7 +129,72 @@ export default async function TreasuryPage({
             </CardContent>
           </Card>
         </UrlTabsContent>
+
+        <UrlTabsContent value="retentions">
+          {tab === 'retentions' && (
+            <Suspense fallback={<PageTableSkeleton />}>
+              <RetentionsView searchParams={resolved as any} />
+            </Suspense>
+          )}
+        </UrlTabsContent>
+
+        <UrlTabsContent value="pending-balances">
+          {tab === 'pending-balances' && (
+            <Suspense fallback={<PageTableSkeleton />}>
+              <PendingBalancesTabContent
+                supplier={resolved.supplier}
+                opStatus={resolved.op_status}
+                search={resolved.search}
+                page={resolved.page}
+              />
+            </Suspense>
+          )}
+        </UrlTabsContent>
       </UrlTabs>
     </div>
+  );
+}
+
+async function PendingBalancesTabContent({
+  supplier,
+  opStatus,
+  search,
+  page: pageParam,
+}: {
+  supplier?: string;
+  opStatus?: string;
+  search?: string;
+  page?: string;
+}) {
+  const page = pageParam ? Math.max(1, parseInt(pageParam, 10) || 1) : 1;
+  const pageSize = 25;
+  const validOpStatus =
+    opStatus === 'NONE' || opStatus === 'SCHEDULED' ? opStatus : null;
+
+  const [result, suppliers] = await Promise.all([
+    listPendingInvoices({
+      supplier_id: supplier ?? null,
+      op_status: validOpStatus,
+      search: search ?? null,
+      page,
+      pageSize,
+    }),
+    getSuppliersWithPendingInvoices(),
+  ]);
+
+  return (
+    <PendingBalancesView
+      rows={result.rows}
+      total={result.total}
+      summary={result.summary}
+      suppliers={suppliers}
+      page={page}
+      pageSize={pageSize}
+      initialFilters={{
+        supplier_id: supplier,
+        op_status: opStatus,
+        search,
+      }}
+    />
   );
 }

--- a/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
+++ b/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
@@ -41,6 +41,13 @@ export default async function EditPaymentOrderPage({
       card_last4: p.card_last4 ?? '',
       reference: p.reference ?? '',
     })),
+    retentions: order.retentions.map((r) => ({
+      tax_type_id: r.tax_type_id,
+      base_amount: r.base_amount.toFixed(2),
+      rate: String(r.rate),
+      amount: r.amount.toFixed(2),
+      notes: r.notes ?? '',
+    })),
   };
 
   return (

--- a/src/app/dashboard/treasury/payment-orders/[id]/page.tsx
+++ b/src/app/dashboard/treasury/payment-orders/[id]/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from 'react';
 import PageTableSkeleton from '@/shared/components/common/Skeletons/PageTableSkeleton';
 import { PaymentOrderDetail } from '@/modules/treasury/features/payment-orders/components/PaymentOrderDetail';
 
+export const dynamic = 'force-dynamic';
+
 export default async function PaymentOrderDetailPage({
   params,
 }: {

--- a/src/app/dashboard/treasury/retentions/page.tsx
+++ b/src/app/dashboard/treasury/retentions/page.tsx
@@ -1,12 +1,12 @@
 import { redirect } from 'next/navigation';
 
-export default async function PendingBalancesPage({
+export default async function RetentionsPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const sp = await searchParams;
-  const params = new URLSearchParams({ tab: 'pending-balances' });
+  const params = new URLSearchParams({ tab: 'retentions' });
   for (const [k, v] of Object.entries(sp)) {
     if (typeof v === 'string') params.set(k, v);
   }

--- a/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
+++ b/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
@@ -45,12 +45,21 @@ type LineField = {
   order_full_number?: string;
 };
 
+interface PerceptionTypeOpt {
+  id: string;
+  code: string;
+  name: string;
+  default_rate: number;
+  calculation_base: 'NET' | 'TOTAL' | 'VAT';
+}
+
 interface Props {
   suppliers: { id: string; code: string; business_name: string }[];
   products: { id: string; code: string; name: string; cost_price: number; vat_rate: number }[];
+  perceptionTypes: PerceptionTypeOpt[];
 }
 
-export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
+export default function PurchaseInvoiceForm({ suppliers, products, perceptionTypes }: Props) {
   const router = useRouter();
   const [availableOrders, setAvailableOrders] = useState<any[]>([]);
   const [attachment, setAttachment] = useState<File | null>(null);
@@ -64,11 +73,18 @@ export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
       purchase_order_id: '',
       purchase_order_ids: [],
       lines: [{ product_id: '', description: '', quantity: 1, unit_cost: 0, vat_rate: 21 }],
+      perceptions: [],
     },
   });
 
   const { fields, append, remove, replace } = useFieldArray({ control: form.control, name: 'lines' });
+  const {
+    fields: perceptionFields,
+    append: appendPerception,
+    remove: removePerception,
+  } = useFieldArray({ control: form.control, name: 'perceptions' });
   const watchedLines = useWatch({ control: form.control, name: 'lines' });
+  const watchedPerceptions = useWatch({ control: form.control, name: 'perceptions' });
   const watchedSupplier = useWatch({ control: form.control, name: 'supplier_id' });
   const watchedOrderIds = (useWatch({ control: form.control, name: 'purchase_order_ids' }) as string[]) || [];
 
@@ -149,8 +165,42 @@ export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
       const s = (l.quantity || 0) * (l.unit_cost || 0);
       subtotal += s; vatAmount += s * ((l.vat_rate || 0) / 100);
     });
-    return { subtotal, vatAmount, total: subtotal + vatAmount };
-  }, [watchedLines]);
+    const otherTaxes = (watchedPerceptions || []).reduce(
+      (acc: number, p: any) => acc + (Number(p?.amount) || 0),
+      0
+    );
+    return {
+      subtotal,
+      vatAmount,
+      otherTaxes,
+      total: subtotal + vatAmount + otherTaxes,
+    };
+  }, [watchedLines, watchedPerceptions]);
+
+  const handlePerceptionTypeChange = (index: number, taxTypeId: string) => {
+    const t = perceptionTypes.find((p) => p.id === taxTypeId);
+    if (!t) return;
+    // Sugerir base según calculation_base del tipo y alícuota default.
+    const base =
+      t.calculation_base === 'NET'
+        ? totals.subtotal
+        : t.calculation_base === 'VAT'
+          ? totals.vatAmount
+          : totals.subtotal + totals.vatAmount;
+    const amount = Math.round(base * (t.default_rate / 100) * 100) / 100;
+    form.setValue(`perceptions.${index}.tax_type_id`, taxTypeId);
+    form.setValue(`perceptions.${index}.base_amount`, Math.round(base * 100) / 100);
+    form.setValue(`perceptions.${index}.rate`, t.default_rate);
+    form.setValue(`perceptions.${index}.amount`, amount);
+  };
+
+  const recalcPerceptionAmount = (index: number) => {
+    const p = form.getValues(`perceptions.${index}`);
+    const base = Number(p?.base_amount) || 0;
+    const rate = Number(p?.rate) || 0;
+    const amount = Math.round(base * (rate / 100) * 100) / 100;
+    form.setValue(`perceptions.${index}.amount`, amount);
+  };
 
   const handleProductSelect = (index: number, productId: string) => {
     const product = products.find((p) => p.id === productId);
@@ -203,6 +253,13 @@ export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
         notes: values.notes,
         purchase_order_ids: values.purchase_order_ids || [],
         lines,
+        perceptions: (values.perceptions || []).map((p) => ({
+          tax_type_id: p.tax_type_id,
+          base_amount: Number(p.base_amount) || 0,
+          rate: Number(p.rate) || 0,
+          amount: Number(p.amount) || 0,
+          notes: p.notes,
+        })),
       } as any);
       if (result.error) throw new Error(result.error);
 
@@ -355,8 +412,122 @@ export default function PurchaseInvoiceForm({ suppliers, products }: Props) {
             <div className="flex justify-end mt-4 text-sm"><div className="text-right space-y-1">
               <p>Subtotal: <span className="font-mono font-medium">${totals.subtotal.toFixed(2)}</span></p>
               <p>IVA: <span className="font-mono font-medium">${totals.vatAmount.toFixed(2)}</span></p>
+              {totals.otherTaxes > 0 && (
+                <p>Percepciones: <span className="font-mono font-medium">${totals.otherTaxes.toFixed(2)}</span></p>
+              )}
               <p className="text-lg font-bold">Total: <span className="font-mono">${totals.total.toFixed(2)}</span></p>
             </div></div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>Percepciones</CardTitle>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  appendPerception({ tax_type_id: '', base_amount: 0, rate: 0, amount: 0, notes: '' })
+                }
+                disabled={perceptionTypes.length === 0}
+              >
+                <Plus className="size-4 mr-1" /> Agregar percepción
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {perceptionTypes.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No hay tipos de percepción configurados. Andá a Configuración → Impuestos
+                para crear los que necesites.
+              </p>
+            ) : perceptionFields.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Si la factura del proveedor incluye percepciones (ej. IIBB Neuquén),
+                agregalas para que el total cuadre.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[280px]">Tipo</TableHead>
+                    <TableHead className="w-[140px]">Base</TableHead>
+                    <TableHead className="w-[100px]">Alícuota %</TableHead>
+                    <TableHead className="w-[140px] text-right">Monto</TableHead>
+                    <TableHead>Notas</TableHead>
+                    <TableHead className="w-[40px]"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {perceptionFields.map((field, index) => (
+                    <TableRow key={field.id}>
+                      <TableCell>
+                        <Select
+                          value={form.watch(`perceptions.${index}.tax_type_id`) || ''}
+                          onValueChange={(v) => handlePerceptionTypeChange(index, v)}
+                        >
+                          <SelectTrigger className="h-8 text-xs">
+                            <SelectValue placeholder="Seleccionar" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {perceptionTypes.map((t) => (
+                              <SelectItem key={t.id} value={t.id}>
+                                {t.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="h-8 text-sm"
+                          type="number"
+                          step="0.01"
+                          {...form.register(`perceptions.${index}.base_amount`, { valueAsNumber: true })}
+                          onBlur={() => recalcPerceptionAmount(index)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="h-8 text-sm"
+                          type="number"
+                          step="0.0001"
+                          {...form.register(`perceptions.${index}.rate`, { valueAsNumber: true })}
+                          onBlur={() => recalcPerceptionAmount(index)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="h-8 text-sm text-right font-mono"
+                          type="number"
+                          step="0.01"
+                          {...form.register(`perceptions.${index}.amount`, { valueAsNumber: true })}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          className="h-8 text-sm"
+                          {...form.register(`perceptions.${index}.notes`)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="size-7"
+                          onClick={() => removePerception(index)}
+                        >
+                          <Trash2 className="size-3.5 text-destructive" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
           </CardContent>
         </Card>
 

--- a/src/modules/purchasing/features/invoices/list/actions.server.ts
+++ b/src/modules/purchasing/features/invoices/list/actions.server.ts
@@ -103,6 +103,7 @@ export async function createPurchaseInvoice(data: {
   purchase_order_id?: string;
   purchase_order_ids?: string[];
   lines: { product_id?: string; description: string; quantity: number; unit_cost: number; vat_rate: number; purchase_order_line_id?: string }[];
+  perceptions?: { tax_type_id: string; base_amount: number; rate: number; amount: number; notes?: string }[];
 }) {
   const { companyId } = await getActionContext();
   if (!companyId) throw new Error('No company selected');
@@ -128,7 +129,30 @@ export async function createPurchaseInvoice(data: {
 
     const subtotal = lines.reduce((s, l) => s + l.subtotal, 0);
     const vatAmount = lines.reduce((s, l) => s + l.vat_amount, 0);
-    const total = lines.reduce((s, l) => s + l.total, 0);
+    const linesTotal = lines.reduce((s, l) => s + l.total, 0);
+
+    // Percepciones cargadas por el usuario (vienen del proveedor en la factura).
+    const perceptions = (data.perceptions ?? []).map((p) => ({
+      tax_type_id: p.tax_type_id,
+      base_amount: Math.round(p.base_amount * 100) / 100,
+      rate: p.rate,
+      amount: Math.round(p.amount * 100) / 100,
+      notes: p.notes?.trim() || null,
+    }));
+    const otherTaxes = perceptions.reduce((s, p) => s + p.amount, 0);
+    const total = Math.round((linesTotal + otherTaxes) * 100) / 100;
+
+    // Validar que los tax_types pertenezcan a la empresa y sean de tipo PERCEPTION.
+    if (perceptions.length > 0) {
+      const taxTypeIds = Array.from(new Set(perceptions.map((p) => p.tax_type_id)));
+      const validTaxes = await prisma.tax_types.findMany({
+        where: { id: { in: taxTypeIds }, company_id: companyId, kind: 'PERCEPTION' },
+        select: { id: true },
+      });
+      if (validTaxes.length !== taxTypeIds.length) {
+        return { data: null, error: 'Alguna percepción tiene un tipo inválido' };
+      }
+    }
 
     // Derivar la OC primaria:
     // - Si viene purchase_order_ids: usarlo (null si hay 0 o >1)
@@ -155,8 +179,10 @@ export async function createPurchaseInvoice(data: {
         purchase_order_id: primaryOrderId,
         subtotal,
         vat_amount: vatAmount,
+        other_taxes: otherTaxes,
         total,
         lines: { create: lines },
+        ...(perceptions.length > 0 ? { perceptions: { create: perceptions } } : {}),
       },
     });
 

--- a/src/modules/purchasing/shared/validators.ts
+++ b/src/modules/purchasing/shared/validators.ts
@@ -38,6 +38,14 @@ export const purchaseInvoiceLineSchema = z.object({
   order_full_number: z.string().optional().or(z.literal('')),
 });
 
+export const purchaseInvoicePerceptionSchema = z.object({
+  tax_type_id: z.string().uuid('Seleccione un tipo de percepción'),
+  base_amount: z.coerce.number().min(0, 'Base no puede ser negativa'),
+  rate: z.coerce.number().min(0).max(100, 'Alícuota fuera de rango'),
+  amount: z.coerce.number().min(0, 'Monto no puede ser negativo'),
+  notes: z.string().optional().or(z.literal('')),
+});
+
 export const purchaseInvoiceSchema = z.object({
   supplier_id: z.string().uuid('Seleccione un proveedor'),
   voucher_type: z.enum(['FACTURA_A', 'FACTURA_B', 'FACTURA_C', 'NOTA_CREDITO_A', 'NOTA_CREDITO_B', 'NOTA_CREDITO_C', 'NOTA_DEBITO_A', 'NOTA_DEBITO_B', 'NOTA_DEBITO_C', 'RECIBO']),
@@ -50,6 +58,7 @@ export const purchaseInvoiceSchema = z.object({
   purchase_order_id: z.string().uuid().optional().or(z.literal('')),
   purchase_order_ids: z.array(z.string().uuid()).optional().default([]),
   lines: z.array(purchaseInvoiceLineSchema).min(1, 'Debe agregar al menos una línea'),
+  perceptions: z.array(purchaseInvoicePerceptionSchema).optional().default([]),
   attachment: z.any().optional(),
 });
 

--- a/src/modules/settings/features/parameters/components/SettingsView.tsx
+++ b/src/modules/settings/features/parameters/components/SettingsView.tsx
@@ -25,11 +25,12 @@ import { getPdfEmailSettings, getPdfSettings } from '@/modules/settings/features
 import { PdfSettingsForm } from '@/modules/settings/features/pdf/components/PdfSettingsForm';
 import { PdfEmailSettingsForm } from '@/modules/settings/features/pdf/components/PdfEmailSettingsForm';
 import RolesAndPermissionsSection from '@/modules/settings/features/roles/components/RolesAndPermissionsSection';
+import TaxesSection from '@/modules/settings/features/taxes/components/TaxesSection';
 import { can } from '@/shared/lib/permissions';
 import { getSession } from '@/shared/lib/session';
 import { prisma } from '@/shared/lib/prisma';
 
-const VALID_SECTIONS = ['employees', 'pdf', 'roles'] as const;
+const VALID_SECTIONS = ['employees', 'pdf', 'roles', 'taxes'] as const;
 type Section = (typeof VALID_SECTIONS)[number];
 
 interface Props {
@@ -41,7 +42,10 @@ export default async function SettingsView({ currentSection }: Props) {
     ? (currentSection as Section)
     : 'employees';
 
-  const canViewRoles = await can('roles.view');
+  const [canViewRoles, canManageTaxes] = await Promise.all([
+    can('roles.view'),
+    can('empresa.update'),
+  ]);
 
   return (
     <section className="space-y-4">
@@ -54,6 +58,7 @@ export default async function SettingsView({ currentSection }: Props) {
         <UrlTabsList>
           <UrlTabsTrigger value="employees">Empleados</UrlTabsTrigger>
           <UrlTabsTrigger value="pdf">PDF</UrlTabsTrigger>
+          {canManageTaxes && <UrlTabsTrigger value="taxes">Impuestos</UrlTabsTrigger>}
           {canViewRoles && <UrlTabsTrigger value="roles">Roles y permisos</UrlTabsTrigger>}
         </UrlTabsList>
 
@@ -64,6 +69,12 @@ export default async function SettingsView({ currentSection }: Props) {
         <UrlTabsContent value="pdf">
           {section === 'pdf' && <PdfSection />}
         </UrlTabsContent>
+
+        {canManageTaxes && (
+          <UrlTabsContent value="taxes">
+            {section === 'taxes' && <TaxesSection />}
+          </UrlTabsContent>
+        )}
 
         {canViewRoles && (
           <UrlTabsContent value="roles">

--- a/src/modules/settings/features/taxes/actions.server.ts
+++ b/src/modules/settings/features/taxes/actions.server.ts
@@ -1,0 +1,181 @@
+'use server';
+
+import { prisma } from '@/shared/lib/prisma';
+import { getActionContext } from '@/shared/lib/server-action-context';
+import { requirePermission } from '@/shared/lib/permissions';
+import { revalidatePath } from 'next/cache';
+import type { TaxTypeData } from './types';
+
+const CODE_RE = /^[A-Z0-9_]+$/;
+
+function serialize(t: {
+  id: string;
+  code: string;
+  name: string;
+  kind: 'RETENTION' | 'PERCEPTION';
+  scope: 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL';
+  jurisdiction: string | null;
+  calculation_base: 'NET' | 'TOTAL' | 'VAT';
+  default_rate: { toString(): string };
+  min_taxable_amount: { toString(): string } | null;
+  is_active: boolean;
+  notes: string | null;
+}): TaxTypeData {
+  return {
+    id: t.id,
+    code: t.code,
+    name: t.name,
+    kind: t.kind,
+    scope: t.scope,
+    jurisdiction: t.jurisdiction,
+    calculation_base: t.calculation_base,
+    default_rate: Number(t.default_rate),
+    min_taxable_amount: t.min_taxable_amount !== null ? Number(t.min_taxable_amount) : null,
+    is_active: t.is_active,
+    notes: t.notes,
+  };
+}
+
+export async function listTaxTypes(kind?: 'RETENTION' | 'PERCEPTION'): Promise<TaxTypeData[]> {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  const rows = await prisma.tax_types.findMany({
+    where: { company_id: companyId, ...(kind ? { kind } : {}) },
+    orderBy: [{ kind: 'asc' }, { name: 'asc' }],
+  });
+  return rows.map(serialize);
+}
+
+interface UpsertInput {
+  id?: string;
+  code: string;
+  name: string;
+  kind: 'RETENTION' | 'PERCEPTION';
+  scope: 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL';
+  jurisdiction?: string | null;
+  calculation_base: 'NET' | 'TOTAL' | 'VAT';
+  default_rate: number;
+  min_taxable_amount?: number | null;
+  is_active: boolean;
+  notes?: string | null;
+}
+
+export async function upsertTaxType(input: UpsertInput) {
+  try {
+    await requirePermission('empresa.update');
+    const { companyId } = await getActionContext();
+    if (!companyId) return { error: 'No company selected' };
+
+    const code = input.code.trim().toUpperCase();
+    if (!code) return { error: 'El código es requerido' };
+    if (!CODE_RE.test(code)) {
+      return { error: 'Código inválido: solo mayúsculas, números y guion bajo' };
+    }
+    if (!input.name.trim()) return { error: 'El nombre es requerido' };
+    if (input.default_rate < 0 || input.default_rate > 100) {
+      return { error: 'La alícuota debe estar entre 0 y 100' };
+    }
+    if (
+      input.min_taxable_amount !== null &&
+      input.min_taxable_amount !== undefined &&
+      input.min_taxable_amount < 0
+    ) {
+      return { error: 'El mínimo no puede ser negativo' };
+    }
+
+    // Validar unicidad de code dentro de la empresa
+    const collision = await prisma.tax_types.findFirst({
+      where: {
+        company_id: companyId,
+        code,
+        ...(input.id ? { id: { not: input.id } } : {}),
+      },
+      select: { id: true },
+    });
+    if (collision) return { error: `Ya existe un tipo con el código "${code}"` };
+
+    const data = {
+      code,
+      name: input.name.trim(),
+      kind: input.kind,
+      scope: input.scope,
+      jurisdiction: input.jurisdiction?.trim() || null,
+      calculation_base: input.calculation_base,
+      default_rate: input.default_rate,
+      min_taxable_amount:
+        input.min_taxable_amount === null || input.min_taxable_amount === undefined
+          ? null
+          : input.min_taxable_amount,
+      is_active: input.is_active,
+      notes: input.notes?.trim() || null,
+    };
+
+    if (input.id) {
+      await prisma.tax_types.update({ where: { id: input.id }, data });
+    } else {
+      await prisma.tax_types.create({ data: { ...data, company_id: companyId } });
+    }
+
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error upserting tax_type:', error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function toggleTaxTypeActive(id: string) {
+  try {
+    await requirePermission('empresa.update');
+    const { companyId } = await getActionContext();
+    if (!companyId) return { error: 'No company selected' };
+
+    const current = await prisma.tax_types.findFirst({
+      where: { id, company_id: companyId },
+      select: { id: true, is_active: true },
+    });
+    if (!current) return { error: 'Tipo no encontrado' };
+
+    await prisma.tax_types.update({
+      where: { id },
+      data: { is_active: !current.is_active },
+    });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error toggling tax_type:', error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function deleteTaxType(id: string) {
+  try {
+    await requirePermission('empresa.update');
+    const { companyId } = await getActionContext();
+    if (!companyId) return { error: 'No company selected' };
+
+    const current = await prisma.tax_types.findFirst({
+      where: { id, company_id: companyId },
+      select: {
+        id: true,
+        _count: { select: { invoice_perceptions: true, order_retentions: true } },
+      },
+    });
+    if (!current) return { error: 'Tipo no encontrado' };
+
+    const used = current._count.invoice_perceptions + current._count.order_retentions;
+    if (used > 0) {
+      return {
+        error: `No se puede eliminar: ya fue usado en ${used} comprobante(s). Desactivalo en su lugar.`,
+      };
+    }
+
+    await prisma.tax_types.delete({ where: { id } });
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error deleting tax_type:', error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/src/modules/settings/features/taxes/components/TaxTypeEditorDialog.tsx
+++ b/src/modules/settings/features/taxes/components/TaxTypeEditorDialog.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Label } from '@/shared/components/ui/label';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { Switch } from '@/shared/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { upsertTaxType } from '../actions.server';
+import {
+  TAX_CALCULATION_BASE_LABELS,
+  TAX_KIND_LABELS,
+  TAX_SCOPE_LABELS,
+  type TaxTypeData,
+} from '../types';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  /** undefined = create; TaxTypeData = edit */
+  taxType?: TaxTypeData;
+  /** Forzar el kind cuando se crea desde una sub-tab. */
+  defaultKind?: 'RETENTION' | 'PERCEPTION';
+}
+
+export function TaxTypeEditorDialog({ open, onOpenChange, taxType, defaultKind }: Props) {
+  const router = useRouter();
+  const isEdit = !!taxType;
+  const [isPending, startTransition] = useTransition();
+
+  const [form, setForm] = useState({
+    code: '',
+    name: '',
+    kind: (defaultKind ?? 'RETENTION') as 'RETENTION' | 'PERCEPTION',
+    scope: 'NATIONAL' as 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL',
+    jurisdiction: '',
+    calculation_base: 'NET' as 'NET' | 'TOTAL' | 'VAT',
+    default_rate: '',
+    min_taxable_amount: '',
+    is_active: true,
+    notes: '',
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (taxType) {
+      setForm({
+        code: taxType.code,
+        name: taxType.name,
+        kind: taxType.kind,
+        scope: taxType.scope,
+        jurisdiction: taxType.jurisdiction ?? '',
+        calculation_base: taxType.calculation_base,
+        default_rate: String(taxType.default_rate),
+        min_taxable_amount:
+          taxType.min_taxable_amount !== null ? String(taxType.min_taxable_amount) : '',
+        is_active: taxType.is_active,
+        notes: taxType.notes ?? '',
+      });
+    } else {
+      setForm((f) => ({
+        ...f,
+        code: '',
+        name: '',
+        kind: defaultKind ?? f.kind,
+        scope: 'NATIONAL',
+        jurisdiction: '',
+        calculation_base: 'NET',
+        default_rate: '',
+        min_taxable_amount: '',
+        is_active: true,
+        notes: '',
+      }));
+    }
+  }, [open, taxType, defaultKind]);
+
+  const handleSubmit = () => {
+    const rate = parseFloat(form.default_rate);
+    if (Number.isNaN(rate)) {
+      toast.error('Ingresá una alícuota válida');
+      return;
+    }
+    const min =
+      form.min_taxable_amount.trim() === ''
+        ? null
+        : parseFloat(form.min_taxable_amount);
+    if (min !== null && Number.isNaN(min)) {
+      toast.error('El mínimo debe ser un número');
+      return;
+    }
+
+    startTransition(async () => {
+      const r = await upsertTaxType({
+        id: taxType?.id,
+        code: form.code,
+        name: form.name,
+        kind: form.kind,
+        scope: form.scope,
+        jurisdiction: form.jurisdiction || null,
+        calculation_base: form.calculation_base,
+        default_rate: rate,
+        min_taxable_amount: min,
+        is_active: form.is_active,
+        notes: form.notes || null,
+      });
+      if (r.error) {
+        toast.error(r.error);
+        return;
+      }
+      toast.success(isEdit ? 'Tipo actualizado' : 'Tipo creado');
+      onOpenChange(false);
+      router.refresh();
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Editar tipo' : 'Nuevo tipo de impuesto'}</DialogTitle>
+          <DialogDescription>
+            Configurá el tipo, alícuota default y base de cálculo. Estos valores se usan
+            como punto de partida cuando se aplica al cargar facturas o al pagar OPs.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-kind">Tipo</Label>
+            <Select
+              value={form.kind}
+              onValueChange={(v: 'RETENTION' | 'PERCEPTION') =>
+                setForm((f) => ({ ...f, kind: v }))
+              }
+            >
+              <SelectTrigger id="tt-kind">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TAX_KIND_LABELS).map(([k, label]) => (
+                  <SelectItem key={k} value={k}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-code">Código</Label>
+            <Input
+              id="tt-code"
+              placeholder="RET_IIBB_NEU"
+              value={form.code}
+              onChange={(e) => setForm((f) => ({ ...f, code: e.target.value.toUpperCase() }))}
+            />
+          </div>
+
+          <div className="col-span-2 grid gap-1.5">
+            <Label htmlFor="tt-name">Nombre visible</Label>
+            <Input
+              id="tt-name"
+              placeholder="Retención IIBB Neuquén"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-scope">Alcance</Label>
+            <Select
+              value={form.scope}
+              onValueChange={(v: 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL') =>
+                setForm((f) => ({ ...f, scope: v }))
+              }
+            >
+              <SelectTrigger id="tt-scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TAX_SCOPE_LABELS).map(([k, label]) => (
+                  <SelectItem key={k} value={k}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-jur">Jurisdicción</Label>
+            <Input
+              id="tt-jur"
+              placeholder={form.scope === 'NATIONAL' ? '— (no aplica)' : 'Neuquén'}
+              value={form.jurisdiction}
+              onChange={(e) => setForm((f) => ({ ...f, jurisdiction: e.target.value }))}
+              disabled={form.scope === 'NATIONAL'}
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-base">Base de cálculo</Label>
+            <Select
+              value={form.calculation_base}
+              onValueChange={(v: 'NET' | 'TOTAL' | 'VAT') =>
+                setForm((f) => ({ ...f, calculation_base: v }))
+              }
+            >
+              <SelectTrigger id="tt-base">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TAX_CALCULATION_BASE_LABELS).map(([k, label]) => (
+                  <SelectItem key={k} value={k}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tt-rate">Alícuota default (%)</Label>
+            <Input
+              id="tt-rate"
+              type="number"
+              step="0.0001"
+              min="0"
+              max="100"
+              placeholder="1.00"
+              value={form.default_rate}
+              onChange={(e) => setForm((f) => ({ ...f, default_rate: e.target.value }))}
+            />
+          </div>
+
+          <div className="col-span-2 grid gap-1.5">
+            <Label htmlFor="tt-min">Mínimo no imponible (opcional)</Label>
+            <Input
+              id="tt-min"
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="Sin mínimo"
+              value={form.min_taxable_amount}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, min_taxable_amount: e.target.value }))
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              Si la base está por debajo de este monto, no se aplica el impuesto.
+            </p>
+          </div>
+
+          <div className="col-span-2 grid gap-1.5">
+            <Label htmlFor="tt-notes">Notas (opcional)</Label>
+            <Textarea
+              id="tt-notes"
+              rows={2}
+              value={form.notes}
+              onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+            />
+          </div>
+
+          <div className="col-span-2 flex items-center gap-2">
+            <Switch
+              id="tt-active"
+              checked={form.is_active}
+              onCheckedChange={(v) => setForm((f) => ({ ...f, is_active: v }))}
+            />
+            <Label htmlFor="tt-active" className="cursor-pointer">
+              Activo
+            </Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isEdit ? 'Guardar' : 'Crear'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/settings/features/taxes/components/TaxTypesList.tsx
+++ b/src/modules/settings/features/taxes/components/TaxTypesList.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/shared/components/ui/button';
+import { Badge } from '@/shared/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { TaxTypeEditorDialog } from './TaxTypeEditorDialog';
+import { deleteTaxType, toggleTaxTypeActive } from '../actions.server';
+import {
+  TAX_CALCULATION_BASE_LABELS,
+  TAX_SCOPE_LABELS,
+  type TaxTypeData,
+} from '../types';
+
+interface Props {
+  taxTypes: TaxTypeData[];
+  kind: 'RETENTION' | 'PERCEPTION';
+}
+
+export function TaxTypesList({ taxTypes, kind }: Props) {
+  const router = useRouter();
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<TaxTypeData | undefined>();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const filtered = taxTypes.filter((t) => t.kind === kind);
+
+  const openCreate = () => {
+    setEditing(undefined);
+    setEditorOpen(true);
+  };
+
+  const openEdit = (t: TaxTypeData) => {
+    setEditing(t);
+    setEditorOpen(true);
+  };
+
+  const handleToggle = (id: string) => {
+    startTransition(async () => {
+      const r = await toggleTaxTypeActive(id);
+      if (r.error) toast.error(r.error);
+      else router.refresh();
+    });
+  };
+
+  const handleDelete = () => {
+    if (!deletingId) return;
+    const id = deletingId;
+    setDeletingId(null);
+    startTransition(async () => {
+      const r = await deleteTaxType(id);
+      if (r.error) {
+        toast.error(r.error);
+        return;
+      }
+      toast.success('Tipo eliminado');
+      router.refresh();
+    });
+  };
+
+  return (
+    <>
+      <div className="flex justify-end">
+        <Button size="sm" onClick={openCreate}>
+          <Plus className="size-4 mr-1" /> Nuevo {kind === 'RETENTION' ? 'retención' : 'percepción'}
+        </Button>
+      </div>
+
+      <div className="rounded-md border mt-3">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Código</TableHead>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Alcance</TableHead>
+              <TableHead>Base</TableHead>
+              <TableHead className="text-right">Alícuota</TableHead>
+              <TableHead className="text-right">Mín.</TableHead>
+              <TableHead className="text-center">Estado</TableHead>
+              <TableHead className="text-right">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center text-sm text-muted-foreground py-8">
+                  No hay tipos configurados.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((t) => (
+                <TableRow key={t.id}>
+                  <TableCell className="font-mono text-xs">{t.code}</TableCell>
+                  <TableCell className="font-medium">
+                    <div>{t.name}</div>
+                    {t.notes && (
+                      <div className="text-xs text-muted-foreground">{t.notes}</div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {TAX_SCOPE_LABELS[t.scope]}
+                    {t.jurisdiction && (
+                      <span className="text-muted-foreground"> — {t.jurisdiction}</span>
+                    )}
+                  </TableCell>
+                  <TableCell>{TAX_CALCULATION_BASE_LABELS[t.calculation_base]}</TableCell>
+                  <TableCell className="text-right">{t.default_rate}%</TableCell>
+                  <TableCell className="text-right">
+                    {t.min_taxable_amount !== null
+                      ? `$${t.min_taxable_amount.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`
+                      : '—'}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(t.id)}
+                      disabled={isPending}
+                      className="inline-flex"
+                      aria-label={t.is_active ? 'Desactivar' : 'Activar'}
+                    >
+                      {t.is_active ? (
+                        <Badge variant="default">Activo</Badge>
+                      ) : (
+                        <Badge variant="secondary">Inactivo</Badge>
+                      )}
+                    </button>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button size="sm" variant="ghost" onClick={() => openEdit(t)}>
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setDeletingId(t.id)}
+                        disabled={isPending}
+                      >
+                        <Trash2 className="size-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <TaxTypeEditorDialog
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        taxType={editing}
+        defaultKind={kind}
+      />
+
+      <AlertDialog open={!!deletingId} onOpenChange={(v) => !v && setDeletingId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar tipo</AlertDialogTitle>
+            <AlertDialogDescription>
+              Vas a eliminar este tipo de impuesto. Si ya fue usado en facturas u órdenes
+              de pago, la operación va a fallar y deberías desactivarlo en su lugar.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Eliminar</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/modules/settings/features/taxes/components/TaxesSection.tsx
+++ b/src/modules/settings/features/taxes/components/TaxesSection.tsx
@@ -1,0 +1,36 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
+import { listTaxTypes } from '../actions.server';
+import { TaxTypesList } from './TaxTypesList';
+
+export default async function TaxesSection() {
+  const taxTypes = await listTaxTypes();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Impuestos: retenciones y percepciones</CardTitle>
+        <CardDescription>
+          Configurá los tipos de impuesto que tu empresa usa. Cada tipo define una
+          alícuota default editable y la base sobre la que se calcula. Las
+          retenciones se aplican al pagar OPs; las percepciones al cargar facturas
+          recibidas.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="retentions" className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="retentions">Retenciones</TabsTrigger>
+            <TabsTrigger value="perceptions">Percepciones</TabsTrigger>
+          </TabsList>
+          <TabsContent value="retentions">
+            <TaxTypesList taxTypes={taxTypes} kind="RETENTION" />
+          </TabsContent>
+          <TabsContent value="perceptions">
+            <TaxTypesList taxTypes={taxTypes} kind="PERCEPTION" />
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/modules/settings/features/taxes/types.ts
+++ b/src/modules/settings/features/taxes/types.ts
@@ -1,0 +1,30 @@
+export const TAX_KIND_LABELS: Record<'RETENTION' | 'PERCEPTION', string> = {
+  RETENTION: 'Retención',
+  PERCEPTION: 'Percepción',
+};
+
+export const TAX_SCOPE_LABELS: Record<'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL', string> = {
+  NATIONAL: 'Nacional',
+  PROVINCIAL: 'Provincial',
+  MUNICIPAL: 'Municipal',
+};
+
+export const TAX_CALCULATION_BASE_LABELS: Record<'NET' | 'TOTAL' | 'VAT', string> = {
+  NET: 'Neto gravado',
+  TOTAL: 'Total',
+  VAT: 'IVA',
+};
+
+export interface TaxTypeData {
+  id: string;
+  code: string;
+  name: string;
+  kind: 'RETENTION' | 'PERCEPTION';
+  scope: 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL';
+  jurisdiction: string | null;
+  calculation_base: 'NET' | 'TOTAL' | 'VAT';
+  default_rate: number;
+  min_taxable_amount: number | null;
+  is_active: boolean;
+  notes: string | null;
+}

--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -5,6 +5,7 @@ import { getActionContext } from '@/shared/lib/server-action-context';
 import { fetchCurrentUser } from '@/shared/actions/auth';
 import { requirePermission } from '@/shared/lib/permissions';
 import { createNotification } from '@/shared/services/notifications';
+import { nextCertificateNumber } from './shared/retention-certificate/sequence';
 import type { DataTableSearchParams } from '@/shared/components/common/DataTable/types';
 import {
   parseSearchParams,
@@ -129,6 +130,14 @@ export async function getPaymentOrderById(id: string) {
           },
         },
       },
+      retentions: {
+        include: {
+          tax_type: {
+            select: { id: true, code: true, name: true, jurisdiction: true, calculation_base: true },
+          },
+        },
+        orderBy: { created_at: 'asc' },
+      },
     },
   });
 
@@ -136,12 +145,20 @@ export async function getPaymentOrderById(id: string) {
   return {
     ...order,
     total_amount: Number(order.total_amount),
+    retentions_total: Number(order.retentions_total),
+    net_to_pay: order.net_to_pay !== null ? Number(order.net_to_pay) : null,
     items: order.items.map((i) => ({
       ...i,
       amount: Number(i.amount),
       invoice: i.invoice ? { ...i.invoice, total: Number(i.invoice.total) } : null,
     })),
     payments: order.payments.map((p) => ({ ...p, amount: Number(p.amount) })),
+    retentions: order.retentions.map((r) => ({
+      ...r,
+      base_amount: Number(r.base_amount),
+      rate: Number(r.rate),
+      amount: Number(r.amount),
+    })),
   };
 }
 
@@ -237,6 +254,26 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
   try {
     await requirePermission('tesoreria.create');
     const totalAmount = parsed.data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
+    const retentions = (parsed.data.retentions ?? []).map((r) => ({
+      tax_type_id: r.tax_type_id,
+      base_amount: Math.round(Number(r.base_amount) * 100) / 100,
+      rate: Number(r.rate),
+      amount: Math.round(Number(r.amount) * 100) / 100,
+      notes: r.notes?.trim() || null,
+    }));
+    const retentionsTotal = retentions.reduce((s, r) => s + r.amount, 0);
+    const netToPay = Math.round((totalAmount - retentionsTotal) * 100) / 100;
+
+    if (retentions.length > 0) {
+      const taxIds = Array.from(new Set(retentions.map((r) => r.tax_type_id)));
+      const valid = await prisma.tax_types.findMany({
+        where: { id: { in: taxIds }, company_id: companyId, kind: 'RETENTION' },
+        select: { id: true },
+      });
+      if (valid.length !== taxIds.length) {
+        return { data: null, error: 'Alguna retención tiene un tipo inválido' };
+      }
+    }
 
     // Validar que cada supplier_payment_method_id pertenezca al supplier de la OP
     const supplierMethodIds = parsed.data.payments
@@ -284,6 +321,8 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
           ? new Date(parsed.data.scheduled_payment_date)
           : null,
         total_amount: Math.round(totalAmount * 100) / 100,
+        retentions_total: retentionsTotal,
+        net_to_pay: netToPay,
         notes: parsed.data.notes || null,
         status: 'DRAFT',
         created_by: user.id,
@@ -305,6 +344,7 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
             reference: p.reference || null,
           })),
         },
+        ...(retentions.length > 0 ? { retentions: { create: retentions } } : {}),
       },
     });
 
@@ -353,6 +393,26 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
   try {
     await requirePermission('tesoreria.update');
     const totalAmount = parsed.data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
+    const retentions = (parsed.data.retentions ?? []).map((r) => ({
+      tax_type_id: r.tax_type_id,
+      base_amount: Math.round(Number(r.base_amount) * 100) / 100,
+      rate: Number(r.rate),
+      amount: Math.round(Number(r.amount) * 100) / 100,
+      notes: r.notes?.trim() || null,
+    }));
+    const retentionsTotal = retentions.reduce((s, r) => s + r.amount, 0);
+    const netToPay = Math.round((totalAmount - retentionsTotal) * 100) / 100;
+
+    if (retentions.length > 0) {
+      const taxIds = Array.from(new Set(retentions.map((r) => r.tax_type_id)));
+      const valid = await prisma.tax_types.findMany({
+        where: { id: { in: taxIds }, company_id: companyId, kind: 'RETENTION' },
+        select: { id: true },
+      });
+      if (valid.length !== taxIds.length) {
+        return { data: null, error: 'Alguna retención tiene un tipo inválido' };
+      }
+    }
 
     const supplierMethodIds = parsed.data.payments
       .map((p) => p.supplier_payment_method_id)
@@ -383,6 +443,7 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
     await prisma.$transaction(async (tx) => {
       await tx.payment_order_items.deleteMany({ where: { payment_order_id: id } });
       await tx.payment_order_payments.deleteMany({ where: { payment_order_id: id } });
+      await tx.payment_order_retentions.deleteMany({ where: { payment_order_id: id } });
 
       await tx.payment_orders.update({
         where: { id },
@@ -393,6 +454,8 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
             ? new Date(parsed.data.scheduled_payment_date)
             : null,
           total_amount: Math.round(totalAmount * 100) / 100,
+          retentions_total: retentionsTotal,
+          net_to_pay: netToPay,
           notes: parsed.data.notes || null,
           items: {
             create: parsed.data.items.map((i) => ({
@@ -412,6 +475,7 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
               reference: p.reference || null,
             })),
           },
+          ...(retentions.length > 0 ? { retentions: { create: retentions } } : {}),
         },
       });
     });
@@ -446,7 +510,7 @@ export async function confirmPaymentOrder(id: string) {
     await requirePermission('tesoreria.confirm');
     const order = await prisma.payment_orders.findFirst({
       where: { id, company_id: companyId },
-      include: { payments: true },
+      include: { payments: true, retentions: true },
     });
     if (!order) return { error: 'Orden no encontrada' };
     if (order.status !== 'DRAFT') return { error: 'Solo se pueden confirmar órdenes en borrador' };
@@ -568,6 +632,17 @@ export async function confirmPaymentOrder(id: string) {
         // manualmente desde el módulo de cheques y el bank_movement se emite
         // cuando el banco lo debita (status CASHED).
         // ACCOUNT: no impacta tesorería.
+      }
+
+      // Asignar certificate_number a las retenciones que aún no lo tengan.
+      // Numeración secuencial por (company, tax_type) atómica vía upsert.
+      for (const r of order.retentions) {
+        if (r.certificate_number) continue;
+        const number = await nextCertificateNumber(tx, companyId, r.tax_type_id);
+        await tx.payment_order_retentions.update({
+          where: { id: r.id },
+          data: { certificate_number: number },
+        });
       }
 
       await tx.payment_orders.update({

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
@@ -137,6 +137,22 @@ function filterMethodsByPaymentMethod(
   return [];
 }
 
+export interface RetentionDraft {
+  tax_type_id: string;
+  base_amount: string;
+  rate: string;
+  amount: string;
+  notes: string;
+}
+
+interface RetentionTypeOpt {
+  id: string;
+  code: string;
+  name: string;
+  default_rate: number;
+  calculation_base: 'NET' | 'TOTAL' | 'VAT';
+}
+
 export interface PaymentOrderEditData {
   id: string;
   supplier_id: string | null;
@@ -159,12 +175,14 @@ export interface PaymentOrderEditData {
     card_last4: string;
     reference: string;
   }>;
+  retentions?: RetentionDraft[];
 }
 
 interface Props {
   suppliers: Supplier[];
   cashRegisters: CashRegisterOpt[];
   bankAccounts: BankAccountOpt[];
+  retentionTypes: RetentionTypeOpt[];
   initialData?: PaymentOrderEditData;
 }
 
@@ -187,6 +205,7 @@ export function NewPaymentOrderForm({
   suppliers,
   cashRegisters,
   bankAccounts,
+  retentionTypes,
   initialData,
 }: Props) {
   const router = useRouter();
@@ -237,6 +256,7 @@ export function NewPaymentOrderForm({
   const [payments, setPayments] = useState<PaymentDraft[]>(
     initialData?.payments ?? [emptyPayment()]
   );
+  const [retentions, setRetentions] = useState<RetentionDraft[]>(initialData?.retentions ?? []);
 
   useEffect(() => {
     if (!supplierId) {
@@ -331,7 +351,51 @@ export function NewPaymentOrderForm({
     () => payments.reduce((acc, p) => acc + (parseFloat(p.amount) || 0), 0),
     [payments]
   );
-  const diff = Math.round((itemsTotal - paymentsTotal) * 100) / 100;
+  const retentionsTotal = useMemo(
+    () => retentions.reduce((acc, r) => acc + (parseFloat(r.amount) || 0), 0),
+    [retentions]
+  );
+  const netToPay = Math.round((itemsTotal - retentionsTotal) * 100) / 100;
+  const diff = Math.round((netToPay - paymentsTotal) * 100) / 100;
+
+  const addRetention = () =>
+    setRetentions((prev) => [
+      ...prev,
+      { tax_type_id: '', base_amount: '', rate: '', amount: '', notes: '' },
+    ]);
+  const removeRetention = (index: number) =>
+    setRetentions((prev) => prev.filter((_, i) => i !== index));
+  const updateRetention = (index: number, patch: Partial<RetentionDraft>) =>
+    setRetentions((prev) => prev.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+
+  const handleRetentionTypeChange = (index: number, taxTypeId: string) => {
+    const t = retentionTypes.find((r) => r.id === taxTypeId);
+    if (!t) {
+      updateRetention(index, { tax_type_id: taxTypeId });
+      return;
+    }
+    // Base sugerida: el total de items (deuda al proveedor). El usuario puede editar.
+    const base = Math.round(itemsTotal * 100) / 100;
+    const amount = Math.round(base * (t.default_rate / 100) * 100) / 100;
+    updateRetention(index, {
+      tax_type_id: taxTypeId,
+      base_amount: base.toFixed(2),
+      rate: String(t.default_rate),
+      amount: amount.toFixed(2),
+    });
+  };
+
+  const recalcRetention = (index: number) => {
+    setRetentions((prev) =>
+      prev.map((r, i) => {
+        if (i !== index) return r;
+        const base = parseFloat(r.base_amount) || 0;
+        const rate = parseFloat(r.rate) || 0;
+        const amount = Math.round(base * (rate / 100) * 100) / 100;
+        return { ...r, amount: amount.toFixed(2) };
+      })
+    );
+  };
 
   const addInvoiceItem = (invoice: InvoiceOption) => {
     if (items.some((i) => i.invoice_id === invoice.id)) {
@@ -403,7 +467,11 @@ export function NewPaymentOrderForm({
       return;
     }
     if (Math.abs(diff) >= 0.01) {
-      toast.error('El total de ítems no coincide con el total de pagos');
+      toast.error('El neto a pagar (ítems − retenciones) no coincide con el total de pagos');
+      return;
+    }
+    if (retentions.some((r) => !r.tax_type_id)) {
+      toast.error('Hay una retención sin tipo seleccionado');
       return;
     }
 
@@ -426,6 +494,13 @@ export function NewPaymentOrderForm({
           check_number: p.check_number.trim() || null,
           card_last4: p.card_last4.trim() || null,
           reference: p.reference.trim() || null,
+        })),
+        retentions: retentions.map((r) => ({
+          tax_type_id: r.tax_type_id,
+          base_amount: parseFloat(r.base_amount) || 0,
+          rate: parseFloat(r.rate) || 0,
+          amount: parseFloat(r.amount) || 0,
+          notes: r.notes.trim() || null,
         })),
       };
 
@@ -827,12 +902,137 @@ export function NewPaymentOrderForm({
       </Card>
 
       <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Retenciones</CardTitle>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={addRetention}
+              disabled={retentionTypes.length === 0 || itemsTotal <= 0}
+            >
+              <Plus className="size-4 mr-1" /> Agregar retención
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {retentionTypes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No hay tipos de retención configurados. Andá a Configuración → Impuestos para
+              crear los que necesites.
+            </p>
+          ) : retentions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Si corresponde aplicar retenciones (Ganancias, IIBB, IVA, SUSS, etc.), agregalas.
+              Reducen el neto a pagar al proveedor.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[260px]">Tipo</TableHead>
+                  <TableHead className="w-[140px]">Base</TableHead>
+                  <TableHead className="w-[100px]">Alícuota %</TableHead>
+                  <TableHead className="w-[140px] text-right">Monto</TableHead>
+                  <TableHead>Notas</TableHead>
+                  <TableHead className="w-[40px]"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {retentions.map((r, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>
+                      <Select
+                        value={r.tax_type_id}
+                        onValueChange={(v) => handleRetentionTypeChange(idx, v)}
+                      >
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue placeholder="Seleccionar" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {retentionTypes.map((t) => (
+                            <SelectItem key={t.id} value={t.id}>
+                              {t.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        className="h-8 text-sm"
+                        type="number"
+                        step="0.01"
+                        value={r.base_amount}
+                        onChange={(e) => updateRetention(idx, { base_amount: e.target.value })}
+                        onBlur={() => recalcRetention(idx)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        className="h-8 text-sm"
+                        type="number"
+                        step="0.0001"
+                        value={r.rate}
+                        onChange={(e) => updateRetention(idx, { rate: e.target.value })}
+                        onBlur={() => recalcRetention(idx)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        className="h-8 text-sm text-right font-mono"
+                        type="number"
+                        step="0.01"
+                        value={r.amount}
+                        onChange={(e) => updateRetention(idx, { amount: e.target.value })}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        className="h-8 text-sm"
+                        value={r.notes}
+                        onChange={(e) => updateRetention(idx, { notes: e.target.value })}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7"
+                        onClick={() => removeRetention(idx)}
+                      >
+                        <Trash2 className="size-3.5 text-destructive" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
         <CardContent className="p-4 flex items-center justify-between">
           <div className="text-sm">
-            <div className="flex gap-6">
+            <div className="flex flex-wrap gap-x-6 gap-y-1">
               <div>
-                <span className="text-muted-foreground">Total ítems:</span>{' '}
+                <span className="text-muted-foreground">Total facturas:</span>{' '}
                 <span className="font-mono font-semibold">${itemsTotal.toFixed(2)}</span>
+              </div>
+              {retentionsTotal > 0 && (
+                <div>
+                  <span className="text-muted-foreground">Retenciones:</span>{' '}
+                  <span className="font-mono font-semibold text-amber-600">
+                    −${retentionsTotal.toFixed(2)}
+                  </span>
+                </div>
+              )}
+              <div>
+                <span className="text-muted-foreground">Neto a pagar:</span>{' '}
+                <span className="font-mono font-semibold">${netToPay.toFixed(2)}</span>
               </div>
               <div>
                 <span className="text-muted-foreground">Total pagos:</span>{' '}

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderShell.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderShell.tsx
@@ -1,6 +1,7 @@
 import { getSuppliersForOrder } from '../actions.server';
 import { getAllCashRegisters } from '../../cash-registers/actions.server';
 import { getAllBankAccounts } from '../../bank-accounts/actions.server';
+import { listTaxTypes } from '@/modules/settings/features/taxes/actions.server';
 import { NewPaymentOrderForm, type PaymentOrderEditData } from './NewPaymentOrderForm';
 
 interface ShellProps {
@@ -8,10 +9,11 @@ interface ShellProps {
 }
 
 export async function NewPaymentOrderShell({ initialData }: ShellProps = {}) {
-  const [suppliers, cashRegisters, bankAccounts] = await Promise.all([
+  const [suppliers, cashRegisters, bankAccounts, retentionTypes] = await Promise.all([
     getSuppliersForOrder(),
     getAllCashRegisters(),
     getAllBankAccounts(),
+    listTaxTypes('RETENTION'),
   ]);
 
   return (
@@ -33,6 +35,15 @@ export async function NewPaymentOrderShell({ initialData }: ShellProps = {}) {
         bank_name: a.bank_name,
         account_number: a.account_number,
       }))}
+      retentionTypes={retentionTypes
+        .filter((t) => t.is_active)
+        .map((t) => ({
+          id: t.id,
+          code: t.code,
+          name: t.name,
+          default_rate: t.default_rate,
+          calculation_base: t.calculation_base,
+        }))}
       initialData={initialData}
     />
   );

--- a/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
+++ b/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
@@ -68,10 +68,24 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
         </Card>
         <Card>
           <CardHeader>
-            <CardDescription>Total</CardDescription>
+            <CardDescription>Total facturas</CardDescription>
             <CardTitle className="text-2xl font-mono">
               ${order.total_amount.toFixed(2)}
             </CardTitle>
+            {order.retentions_total > 0 && order.net_to_pay !== null && (
+              <div className="text-xs text-muted-foreground space-y-0.5 mt-1">
+                <div>
+                  Retenciones:{' '}
+                  <span className="font-mono text-amber-600">
+                    −${order.retentions_total.toFixed(2)}
+                  </span>
+                </div>
+                <div>
+                  Neto pagado:{' '}
+                  <span className="font-mono font-semibold">${order.net_to_pay.toFixed(2)}</span>
+                </div>
+              </div>
+            )}
           </CardHeader>
         </Card>
       </div>
@@ -182,6 +196,64 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
           </Table>
         </CardContent>
       </Card>
+
+      {order.retentions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Retenciones</CardTitle>
+            <CardDescription>
+              Montos retenidos al proveedor. Reducen el neto pagado pero cancelan la
+              cuenta corriente por el total de las facturas.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Concepto</TableHead>
+                  <TableHead className="text-right">Base</TableHead>
+                  <TableHead className="text-right">Alícuota</TableHead>
+                  <TableHead className="text-right">Monto</TableHead>
+                  <TableHead>Certificado</TableHead>
+                  <TableHead>Notas</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {order.retentions.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell>
+                      <div className="font-medium">{r.tax_type.name}</div>
+                      {r.tax_type.jurisdiction && (
+                        <div className="text-xs text-muted-foreground">{r.tax_type.jurisdiction}</div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">${r.base_amount.toFixed(2)}</TableCell>
+                    <TableCell className="text-right font-mono">{r.rate}%</TableCell>
+                    <TableCell className="text-right font-mono font-medium text-amber-600">
+                      ${r.amount.toFixed(2)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {r.certificate_number ? (
+                        <a
+                          href={`/api/retention-certificates/${r.id}/pdf`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {r.certificate_number}
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">{r.notes ?? '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
 
       {order.notes && (
         <Card>

--- a/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
+++ b/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
@@ -5,6 +5,11 @@ import { sendEmail } from '@/shared/actions/email';
 import { resolveEmailSender } from '@/modules/settings/features/pdf/email-resolver';
 import { paymentOrderPaidEmail } from '@/shared/lib/email-templates/payment-order-paid';
 import {
+  buildRetentionCertificateData,
+  generateRetentionCertificatePDF,
+  getRetentionCertificateFileName,
+} from '../retention-certificate';
+import {
   generatePaymentOrderPDF,
   getPaymentOrderFileName,
   amountToSpanishWords,
@@ -65,6 +70,12 @@ export async function sendPaymentOrderPaidEmail(
               },
             },
           },
+        },
+        retentions: {
+          include: {
+            tax_type: { select: { name: true, jurisdiction: true } },
+          },
+          orderBy: { created_at: 'asc' },
         },
       },
     });
@@ -151,13 +162,45 @@ export async function sendPaymentOrderPaidEmail(
         amount: Number(p.amount),
         destination: mapPaymentDestinationForPDF(p.supplier_payment_method),
       })),
+      retentions: order.retentions.map((r) => ({
+        name: r.tax_type.name,
+        jurisdiction: r.tax_type.jurisdiction,
+        baseAmount: Number(r.base_amount),
+        rate: Number(r.rate),
+        amount: Number(r.amount),
+        certificateNumber: r.certificate_number,
+      })),
       totalAmount,
-      amountInWords: amountToSpanishWords(totalAmount),
+      retentionsTotal: Number(order.retentions_total),
+      netToPay:
+        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount,
+      amountInWords: amountToSpanishWords(
+        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount
+      ),
       pdfSettings,
     };
 
     const pdfBuffer = await generatePaymentOrderPDF(pdfData);
     const fileName = getPaymentOrderFileName(pdfData);
+
+    // Generar comprobantes de retención (uno por línea numerada).
+    const retentionAttachments: { filename: string; content: Buffer; contentType: string }[] = [];
+    for (const r of order.retentions) {
+      if (!r.certificate_number) continue;
+      try {
+        const certData = await buildRetentionCertificateData(r.id, companyId);
+        if (!certData) continue;
+        const certBuffer = await generateRetentionCertificatePDF(certData);
+        retentionAttachments.push({
+          filename: getRetentionCertificateFileName(certData),
+          content: certBuffer,
+          contentType: 'application/pdf',
+        });
+      } catch (err) {
+        console.error('Error generando comprobante de retención:', err);
+        // No bloqueamos el envío del mail si un certificado falla.
+      }
+    }
 
     if (!supplierEmail) {
       return { status: 'NO_EMAIL' };
@@ -189,6 +232,7 @@ export async function sendPaymentOrderPaidEmail(
           content: pdfBuffer,
           contentType: 'application/pdf',
         },
+        ...retentionAttachments,
       ],
     });
 

--- a/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
@@ -44,7 +44,10 @@ export function PaymentOrderTemplate({ data }: { data: PaymentOrderPDFData }) {
     supplier,
     invoices,
     payments,
+    retentions = [],
     totalAmount,
+    retentionsTotal = 0,
+    netToPay,
     amountInWords,
     pdfSettings,
   } = data;
@@ -201,10 +204,47 @@ export function PaymentOrderTemplate({ data }: { data: PaymentOrderPDFData }) {
           </View>
         ) : null}
 
+        {retentions.length > 0 ? (
+          <View>
+            <Text style={styles.sectionTitle}>Retenciones</Text>
+            <View style={[styles.tableHeader, { paddingVertical: 4 }]}>
+              <Text style={{ flex: 3, fontSize: 9, fontWeight: 'bold' }}>Concepto</Text>
+              <Text style={{ flex: 1, fontSize: 9, fontWeight: 'bold', textAlign: 'right' }}>Base</Text>
+              <Text style={{ flex: 1, fontSize: 9, fontWeight: 'bold', textAlign: 'right' }}>Alícuota</Text>
+              <Text style={{ flex: 1, fontSize: 9, fontWeight: 'bold', textAlign: 'right' }}>Monto</Text>
+            </View>
+            {retentions.map((r, idx) => (
+              <View key={idx} style={[styles.tableRow, { paddingVertical: 3 }]}>
+                <Text style={{ flex: 3, fontSize: 9 }}>
+                  {r.name}
+                  {r.jurisdiction ? ` (${r.jurisdiction})` : ''}
+                  {r.certificateNumber ? ` · Cert. ${r.certificateNumber}` : ''}
+                </Text>
+                <Text style={{ flex: 1, fontSize: 9, textAlign: 'right' }}>{fmtAmount(r.baseAmount)}</Text>
+                <Text style={{ flex: 1, fontSize: 9, textAlign: 'right' }}>{r.rate}%</Text>
+                <Text style={{ flex: 1, fontSize: 9, textAlign: 'right' }}>{fmtAmount(r.amount)}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
         <View style={styles.grandTotal}>
-          <Text>TOTAL ORDEN DE PAGO</Text>
+          <Text>TOTAL FACTURAS</Text>
           <Text>{fmtAmount(totalAmount)}</Text>
         </View>
+
+        {retentionsTotal > 0 && netToPay !== undefined ? (
+          <>
+            <View style={[styles.grandTotal, { backgroundColor: undefined }]}>
+              <Text style={{ fontSize: 10 }}>Retenciones</Text>
+              <Text style={{ fontSize: 10 }}>−{fmtAmount(retentionsTotal)}</Text>
+            </View>
+            <View style={styles.grandTotal}>
+              <Text>NETO A PAGAR</Text>
+              <Text>{fmtAmount(netToPay)}</Text>
+            </View>
+          </>
+        ) : null}
 
         <View style={styles.amountWords}>
           <Text>Son: {amountInWords}</Text>

--- a/src/modules/treasury/features/payment-orders/shared/pdf/types.ts
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/types.ts
@@ -34,6 +34,15 @@ export interface PaymentOrderPDFPayment {
   destination?: PaymentOrderPDFDestination;
 }
 
+export interface PaymentOrderPDFRetention {
+  name: string;
+  jurisdiction?: string | null;
+  baseAmount: number;
+  rate: number;
+  amount: number;
+  certificateNumber?: string | null;
+}
+
 export interface PaymentOrderPDFData {
   company: CompanyPDFData;
   paymentOrder: {
@@ -53,7 +62,10 @@ export interface PaymentOrderPDFData {
   };
   invoices: PaymentOrderPDFInvoice[];
   payments: PaymentOrderPDFPayment[];
+  retentions?: PaymentOrderPDFRetention[];
   totalAmount: number;
+  retentionsTotal?: number;
+  netToPay?: number;
   amountInWords: string;
   pdfSettings?: {
     headerText?: string | null;

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/RetentionCertificateTemplate.tsx
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/RetentionCertificateTemplate.tsx
@@ -1,0 +1,243 @@
+import { Document, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { RetentionCertificatePDFData } from './types';
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 36,
+    fontSize: 10,
+    fontFamily: 'Helvetica',
+    color: '#222',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    borderBottom: 2,
+    borderBottomColor: '#0f172a',
+    paddingBottom: 12,
+    marginBottom: 12,
+  },
+  companyBlock: { flexDirection: 'row', gap: 10, alignItems: 'center', flex: 1 },
+  logo: { width: 56, height: 56, objectFit: 'contain' },
+  companyName: { fontSize: 13, fontFamily: 'Helvetica-Bold' },
+  companyInfo: { fontSize: 8, color: '#555', marginTop: 2 },
+  certBlock: { alignItems: 'flex-end', minWidth: 200 },
+  certTitle: { fontSize: 14, fontFamily: 'Helvetica-Bold', letterSpacing: 0.5 },
+  certNumber: { fontSize: 12, fontFamily: 'Helvetica-Bold', marginTop: 2 },
+  certMeta: { fontSize: 9, color: '#444', marginTop: 1 },
+
+  sectionTitle: {
+    fontSize: 10,
+    fontFamily: 'Helvetica-Bold',
+    backgroundColor: '#0f172a',
+    color: '#fff',
+    padding: 4,
+    marginTop: 12,
+    marginBottom: 6,
+  },
+  row: { flexDirection: 'row', marginBottom: 3 },
+  label: { width: '35%', color: '#555', fontSize: 9 },
+  value: { flex: 1, fontSize: 9, fontFamily: 'Helvetica-Bold' },
+
+  amountsBox: {
+    marginTop: 8,
+    padding: 10,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: '#cbd5e1',
+    borderRadius: 4,
+  },
+  amountRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  amountLabel: { fontSize: 10, color: '#555' },
+  amountValue: { fontSize: 10, fontFamily: 'Helvetica-Bold' },
+  amountTotal: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 6,
+    paddingTop: 6,
+    borderTop: 1,
+    borderTopColor: '#0f172a',
+  },
+  amountTotalLabel: { fontSize: 12, fontFamily: 'Helvetica-Bold' },
+  amountTotalValue: { fontSize: 12, fontFamily: 'Helvetica-Bold' },
+  inWords: { marginTop: 8, fontSize: 9, fontStyle: 'italic', color: '#444' },
+
+  signatureSection: {
+    marginTop: 50,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  signatureBox: {
+    width: 200,
+    alignItems: 'center',
+    borderTop: 1,
+    borderTopColor: '#0f172a',
+    paddingTop: 4,
+  },
+  signatureImage: {
+    width: 130,
+    height: 50,
+    objectFit: 'contain',
+    marginBottom: 4,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 24,
+    left: 36,
+    right: 36,
+    fontSize: 8,
+    color: '#777',
+    textAlign: 'center',
+    borderTop: 1,
+    borderTopColor: '#cbd5e1',
+    paddingTop: 6,
+  },
+});
+
+const SCOPE_LABEL = {
+  NATIONAL: 'Nacional',
+  PROVINCIAL: 'Provincial',
+  MUNICIPAL: 'Municipal',
+} as const;
+
+const BASE_LABEL = {
+  NET: 'Neto gravado',
+  TOTAL: 'Total',
+  VAT: 'IVA',
+} as const;
+
+function fmtAmount(n: number) {
+  return `$${n.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+}
+
+function fmtDate(d: Date | string) {
+  return format(new Date(d), 'dd/MM/yyyy', { locale: es });
+}
+
+export function RetentionCertificateTemplate({ data }: { data: RetentionCertificatePDFData }) {
+  const { company, certificate, taxType, paymentOrder, retainee, baseAmount, rate, amount, amountInWords, notes, pdfSettings } = data;
+
+  const headerText = pdfSettings?.headerText?.trim() || '';
+  const footerText = pdfSettings?.footerText?.trim() || '';
+
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {headerText ? (
+          <Text style={{ fontSize: 8, color: '#777', textAlign: 'center', marginBottom: 6 }}>
+            {headerText}
+          </Text>
+        ) : null}
+
+        <View style={styles.header}>
+          <View style={styles.companyBlock}>
+            {company.logo ? <Image src={company.logo} style={styles.logo} /> : null}
+            <View>
+              <Text style={styles.companyName}>{company.name}</Text>
+              {company.cuit ? (
+                <Text style={styles.companyInfo}>CUIT: {company.cuit}</Text>
+              ) : null}
+              {company.address ? (
+                <Text style={styles.companyInfo}>{company.address}</Text>
+              ) : null}
+              {company.email ? (
+                <Text style={styles.companyInfo}>{company.email}</Text>
+              ) : null}
+            </View>
+          </View>
+          <View style={styles.certBlock}>
+            <Text style={styles.certTitle}>COMPROBANTE DE RETENCIÓN</Text>
+            <Text style={styles.certNumber}>N° {certificate.number}</Text>
+            <Text style={styles.certMeta}>Emitido: {fmtDate(certificate.issueDate)}</Text>
+            <Text style={styles.certMeta}>Período: {certificate.period}</Text>
+          </View>
+        </View>
+
+        <Text style={styles.sectionTitle}>Sujeto retenido</Text>
+        <View style={styles.row}>
+          <Text style={styles.label}>Razón social</Text>
+          <Text style={styles.value}>{retainee.businessName}</Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>CUIT</Text>
+          <Text style={styles.value}>{retainee.taxId}</Text>
+        </View>
+        {retainee.address ? (
+          <View style={styles.row}>
+            <Text style={styles.label}>Domicilio</Text>
+            <Text style={styles.value}>{retainee.address}</Text>
+          </View>
+        ) : null}
+
+        <Text style={styles.sectionTitle}>Datos del régimen</Text>
+        <View style={styles.row}>
+          <Text style={styles.label}>Régimen</Text>
+          <Text style={styles.value}>
+            {taxType.name} ({taxType.code})
+          </Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>Alcance</Text>
+          <Text style={styles.value}>
+            {SCOPE_LABEL[taxType.scope]}
+            {taxType.jurisdiction ? ` — ${taxType.jurisdiction}` : ''}
+          </Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>Base de cálculo</Text>
+          <Text style={styles.value}>{BASE_LABEL[taxType.calculationBase]}</Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>Comprobante origen</Text>
+          <Text style={styles.value}>
+            Orden de pago {paymentOrder.fullNumber} · {fmtDate(paymentOrder.date)}
+          </Text>
+        </View>
+
+        <View style={styles.amountsBox}>
+          <View style={styles.amountRow}>
+            <Text style={styles.amountLabel}>Base imponible</Text>
+            <Text style={styles.amountValue}>{fmtAmount(baseAmount)}</Text>
+          </View>
+          <View style={styles.amountRow}>
+            <Text style={styles.amountLabel}>Alícuota aplicada</Text>
+            <Text style={styles.amountValue}>{rate}%</Text>
+          </View>
+          <View style={styles.amountTotal}>
+            <Text style={styles.amountTotalLabel}>Importe retenido</Text>
+            <Text style={styles.amountTotalValue}>{fmtAmount(amount)}</Text>
+          </View>
+          <Text style={styles.inWords}>Son: {amountInWords}</Text>
+        </View>
+
+        {notes ? (
+          <>
+            <Text style={styles.sectionTitle}>Observaciones</Text>
+            <Text style={{ fontSize: 9 }}>{notes}</Text>
+          </>
+        ) : null}
+
+        <View style={styles.signatureSection}>
+          <View style={styles.signatureBox}>
+            {pdfSettings?.signatureUrl ? (
+              <Image src={pdfSettings.signatureUrl} style={styles.signatureImage} />
+            ) : null}
+            <Text>Firma del agente de retención</Text>
+          </View>
+        </View>
+
+        {footerText ? (
+          <Text style={styles.footer} fixed>
+            {footerText}
+          </Text>
+        ) : null}
+      </Page>
+    </Document>
+  );
+}

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/builder.ts
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/builder.ts
@@ -1,0 +1,112 @@
+import { prisma } from '@/shared/lib/prisma';
+import { resolveEmailSender } from '@/modules/settings/features/pdf/email-resolver';
+import type { CompanyPDFData } from '@/shared/actions/export';
+import { amountToSpanishWords } from '../pdf/amount-in-words';
+import type { RetentionCertificatePDFData } from './types';
+
+/**
+ * Construye los datos completos para emitir el PDF del comprobante de retención
+ * a partir del ID de la línea payment_order_retentions. Devuelve null si la
+ * retención no existe o todavía no fue numerada (la OP no se confirmó).
+ */
+export async function buildRetentionCertificateData(
+  retentionId: string,
+  expectedCompanyId?: string
+): Promise<RetentionCertificatePDFData | null> {
+  const retention = await prisma.payment_order_retentions.findUnique({
+    where: { id: retentionId },
+    include: {
+      tax_type: true,
+      payment_order: {
+        select: {
+          id: true,
+          full_number: true,
+          date: true,
+          confirmed_at: true,
+          company_id: true,
+          supplier: {
+            select: { business_name: true, tax_id: true, address: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!retention) return null;
+  if (expectedCompanyId && retention.payment_order.company_id !== expectedCompanyId) {
+    return null;
+  }
+  if (!retention.certificate_number) return null;
+
+  const companyId = retention.payment_order.company_id;
+  const [company, pdfSettingsRow, sender] = await Promise.all([
+    prisma.company.findUnique({
+      where: { id: companyId },
+      select: {
+        company_name: true,
+        company_logo: true,
+        company_cuit: true,
+        address: true,
+        contact_phone: true,
+        contact_email: true,
+      },
+    }),
+    prisma.pdf_settings.findUnique({ where: { company_id: companyId } }),
+    resolveEmailSender(companyId, 'payment-order'),
+  ]);
+
+  const isSigned =
+    pdfSettingsRow?.signed_pdf_keys.includes('payment-order') ?? false;
+  const pdfSettings = pdfSettingsRow
+    ? {
+        headerText: pdfSettingsRow.header_text,
+        footerText: pdfSettingsRow.footer_text,
+        signatureUrl: isSigned ? pdfSettingsRow.signature_image_url : null,
+      }
+    : undefined;
+
+  const companyData: CompanyPDFData = {
+    name: company?.company_name ?? '',
+    logo: company?.company_logo ?? null,
+    cuit: company?.company_cuit ?? '',
+    address: company?.address ?? '',
+    phone: company?.contact_phone ?? '',
+    email: sender.replyTo ?? company?.contact_email ?? '',
+  };
+
+  const issueDate = retention.payment_order.confirmed_at ?? retention.payment_order.date;
+  const period = `${String(new Date(issueDate).getMonth() + 1).padStart(2, '0')}/${new Date(issueDate).getFullYear()}`;
+
+  const amount = Number(retention.amount);
+
+  return {
+    company: companyData,
+    certificate: {
+      number: retention.certificate_number,
+      issueDate,
+      period,
+    },
+    taxType: {
+      code: retention.tax_type.code,
+      name: retention.tax_type.name,
+      scope: retention.tax_type.scope,
+      jurisdiction: retention.tax_type.jurisdiction,
+      calculationBase: retention.tax_type.calculation_base,
+    },
+    paymentOrder: {
+      fullNumber: retention.payment_order.full_number,
+      date: retention.payment_order.date,
+    },
+    retainee: {
+      businessName: retention.payment_order.supplier?.business_name ?? 'Sin proveedor',
+      taxId: retention.payment_order.supplier?.tax_id ?? '',
+      address: retention.payment_order.supplier?.address ?? null,
+    },
+    baseAmount: Number(retention.base_amount),
+    rate: Number(retention.rate),
+    amount,
+    amountInWords: amountToSpanishWords(amount),
+    notes: retention.notes,
+    pdfSettings,
+  };
+}

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/generator.tsx
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/generator.tsx
@@ -1,0 +1,14 @@
+import { renderToBuffer } from '@react-pdf/renderer';
+import { RetentionCertificateTemplate } from './RetentionCertificateTemplate';
+import type { RetentionCertificatePDFData } from './types';
+
+export async function generateRetentionCertificatePDF(
+  data: RetentionCertificatePDFData
+): Promise<Buffer> {
+  return renderToBuffer(<RetentionCertificateTemplate data={data} />);
+}
+
+export function getRetentionCertificateFileName(data: RetentionCertificatePDFData): string {
+  const code = data.taxType.code.replace(/[^A-Z0-9_]/gi, '');
+  return `Cert-${code}-${data.certificate.number}.pdf`;
+}

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/index.ts
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/index.ts
@@ -1,0 +1,4 @@
+export { generateRetentionCertificatePDF, getRetentionCertificateFileName } from './generator';
+export { buildRetentionCertificateData } from './builder';
+export { nextCertificateNumber } from './sequence';
+export type { RetentionCertificatePDFData } from './types';

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/sequence.ts
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/sequence.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from '@/generated/prisma/client';
+
+/**
+ * Asigna un número secuencial al comprobante de retención dentro de una
+ * transacción Prisma. Inserta o actualiza la fila en
+ * retention_certificate_sequences atómicamente.
+ *
+ * Devuelve el número formateado como string padded a 8 dígitos
+ * (ej. "00000123") para usar como certificate_number.
+ */
+export async function nextCertificateNumber(
+  tx: Prisma.TransactionClient,
+  companyId: string,
+  taxTypeId: string
+): Promise<string> {
+  // Upsert con incremento atómico. Si la row ya existía suma 1; si no,
+  // la crea con last_number = 1.
+  const seq = await tx.retention_certificate_sequences.upsert({
+    where: {
+      company_id_tax_type_id: { company_id: companyId, tax_type_id: taxTypeId },
+    },
+    update: { last_number: { increment: 1 }, updated_at: new Date() },
+    create: { company_id: companyId, tax_type_id: taxTypeId, last_number: 1 },
+    select: { last_number: true },
+  });
+
+  return String(seq.last_number).padStart(8, '0');
+}

--- a/src/modules/treasury/features/payment-orders/shared/retention-certificate/types.ts
+++ b/src/modules/treasury/features/payment-orders/shared/retention-certificate/types.ts
@@ -1,0 +1,36 @@
+import type { CompanyPDFData } from '@/shared/actions/export';
+
+export interface RetentionCertificatePDFData {
+  company: CompanyPDFData;
+  certificate: {
+    number: string;
+    issueDate: Date | string;
+    period: string; // "MM/YYYY"
+  };
+  taxType: {
+    code: string;
+    name: string;
+    scope: 'NATIONAL' | 'PROVINCIAL' | 'MUNICIPAL';
+    jurisdiction: string | null;
+    calculationBase: 'NET' | 'TOTAL' | 'VAT';
+  };
+  paymentOrder: {
+    fullNumber: string;
+    date: Date | string;
+  };
+  retainee: {
+    businessName: string;
+    taxId: string;
+    address: string | null;
+  };
+  baseAmount: number;
+  rate: number;
+  amount: number;
+  amountInWords: string;
+  notes: string | null;
+  pdfSettings?: {
+    headerText?: string | null;
+    footerText?: string | null;
+    signatureUrl?: string | null;
+  };
+}

--- a/src/modules/treasury/features/retentions/actions.server.ts
+++ b/src/modules/treasury/features/retentions/actions.server.ts
@@ -1,0 +1,213 @@
+'use server';
+
+import { prisma } from '@/shared/lib/prisma';
+import { getActionContext } from '@/shared/lib/server-action-context';
+import type { DataTableSearchParams } from '@/shared/components/common/DataTable/types';
+import {
+  parseSearchParams,
+  stateToPrismaParams,
+  buildDateRangeFiltersWhere,
+} from '@/shared/components/common/DataTable/helpers';
+
+export interface RetentionRow {
+  id: string;
+  certificate_number: string | null;
+  base_amount: number;
+  rate: number;
+  amount: number;
+  notes: string | null;
+  payment_order_id: string;
+  payment_order_full_number: string;
+  payment_order_date: Date;
+  payment_order_status: string;
+  supplier: string;
+  supplier_tax_id: string;
+  tax_type_id: string;
+  tax_type_code: string;
+  tax_type_name: string;
+  tax_type_jurisdiction: string | null;
+}
+
+const RETENTION_INCLUDE = {
+  tax_type: { select: { id: true, code: true, name: true, jurisdiction: true } },
+  payment_order: {
+    select: {
+      id: true,
+      full_number: true,
+      date: true,
+      status: true,
+      supplier: { select: { business_name: true, tax_id: true } },
+    },
+  },
+} as const;
+
+function rowToRetention(r: any): RetentionRow {
+  return {
+    id: r.id,
+    certificate_number: r.certificate_number,
+    base_amount: Number(r.base_amount),
+    rate: Number(r.rate),
+    amount: Number(r.amount),
+    notes: r.notes,
+    payment_order_id: r.payment_order.id,
+    payment_order_full_number: r.payment_order.full_number,
+    payment_order_date: r.payment_order.date,
+    payment_order_status: r.payment_order.status,
+    supplier: r.payment_order.supplier?.business_name ?? 'Sin proveedor',
+    supplier_tax_id: r.payment_order.supplier?.tax_id ?? '',
+    tax_type_id: r.tax_type.id,
+    tax_type_code: r.tax_type.code,
+    tax_type_name: r.tax_type.name,
+    tax_type_jurisdiction: r.tax_type.jurisdiction,
+  };
+}
+
+function buildRetentionsWhere(
+  companyId: string,
+  searchParams: DataTableSearchParams
+): Record<string, unknown> {
+  const state = parseSearchParams(searchParams);
+
+  const orderConditions: Record<string, unknown> = { company_id: companyId };
+
+  const taxTypeFilter = state.filters.tax_type;
+  const statusFilter = state.filters.payment_order_status;
+
+  const dateWhere = buildDateRangeFiltersWhere(state.filters, ['payment_order_date']);
+  const dateFilter = (dateWhere as any).payment_order_date;
+  if (dateFilter) orderConditions.date = dateFilter;
+  if (statusFilter && statusFilter.length > 0) orderConditions.status = { in: statusFilter };
+
+  const supplierFilter = state.filters.supplier?.[0];
+  if (supplierFilter) {
+    orderConditions.supplier = {
+      business_name: { contains: supplierFilter, mode: 'insensitive' },
+    };
+  }
+
+  const where: Record<string, unknown> = { payment_order: orderConditions };
+
+  if (taxTypeFilter && taxTypeFilter.length > 0) {
+    where.tax_type_id = { in: taxTypeFilter };
+  }
+
+  if (state.search) {
+    where.OR = [
+      { certificate_number: { contains: state.search, mode: 'insensitive' } },
+      {
+        payment_order: {
+          ...orderConditions,
+          full_number: { contains: state.search, mode: 'insensitive' },
+        },
+      },
+      {
+        payment_order: {
+          ...orderConditions,
+          supplier: { business_name: { contains: state.search, mode: 'insensitive' } },
+        },
+      },
+    ];
+  }
+
+  return where;
+}
+
+export async function getRetentionsPaginated(
+  searchParams: DataTableSearchParams
+): Promise<{ data: RetentionRow[]; total: number }> {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { data: [], total: 0 };
+
+  try {
+    const state = parseSearchParams(searchParams);
+    const { skip, take } = stateToPrismaParams(state);
+    const where = buildRetentionsWhere(companyId, searchParams);
+
+    const [rows, total] = await Promise.all([
+      prisma.payment_order_retentions.findMany({
+        where: where as any,
+        include: RETENTION_INCLUDE,
+        orderBy: { payment_order: { date: 'desc' } },
+        skip,
+        take,
+      }),
+      prisma.payment_order_retentions.count({ where: where as any }),
+    ]);
+
+    return { data: rows.map(rowToRetention), total };
+  } catch (error) {
+    console.error('Error fetching retentions:', error);
+    return { data: [], total: 0 };
+  }
+}
+
+/**
+ * Mismo where que getRetentionsPaginated pero sin paginación. Pensado para
+ * el botón "Exportar Excel" — respeta los filtros activos.
+ */
+export async function getAllRetentionsForExport(
+  searchParams: DataTableSearchParams
+): Promise<RetentionRow[]> {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  try {
+    const where = buildRetentionsWhere(companyId, searchParams);
+    const rows = await prisma.payment_order_retentions.findMany({
+      where: where as any,
+      include: RETENTION_INCLUDE,
+      orderBy: { payment_order: { date: 'desc' } },
+    });
+    return rows.map(rowToRetention);
+  } catch (error) {
+    console.error('Error exporting retentions:', error);
+    return [];
+  }
+}
+
+export async function getRetentionTypeOptions(): Promise<
+  { id: string; code: string; name: string }[]
+> {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+  return prisma.tax_types.findMany({
+    where: { company_id: companyId, kind: 'RETENTION' },
+    select: { id: true, code: true, name: true },
+    orderBy: { name: 'asc' },
+  });
+}
+
+export interface RetentionsSummary {
+  totalAmount: number;
+  byTaxType: { taxTypeId: string; name: string; total: number; count: number }[];
+}
+
+export async function getRetentionsSummary(): Promise<RetentionsSummary> {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { totalAmount: 0, byTaxType: [] };
+
+  const [groups, taxTypes] = await Promise.all([
+    prisma.payment_order_retentions.groupBy({
+      by: ['tax_type_id'],
+      where: { payment_order: { company_id: companyId } },
+      _sum: { amount: true },
+      _count: { _all: true },
+    }),
+    prisma.tax_types.findMany({
+      where: { company_id: companyId, kind: 'RETENTION' },
+      select: { id: true, name: true },
+    }),
+  ]);
+
+  const nameMap = new Map(taxTypes.map((t) => [t.id, t.name]));
+  const byTaxType = groups.map((g) => ({
+    taxTypeId: g.tax_type_id,
+    name: nameMap.get(g.tax_type_id) ?? 'Sin nombre',
+    total: Number(g._sum.amount ?? 0),
+    count: g._count._all,
+  }));
+  byTaxType.sort((a, b) => b.total - a.total);
+  const totalAmount = byTaxType.reduce((acc, g) => acc + g.total, 0);
+
+  return { totalAmount, byTaxType };
+}

--- a/src/modules/treasury/features/retentions/components/RetentionsView.tsx
+++ b/src/modules/treasury/features/retentions/components/RetentionsView.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
+import { Badge } from '@/shared/components/ui/badge';
+import {
+  getRetentionsPaginated,
+  getRetentionsSummary,
+  getRetentionTypeOptions,
+} from '../actions.server';
+import { RetentionsDataTable } from './_RetentionsDataTable';
+import type { DataTableSearchParams } from '@/shared/components/common/DataTable/types';
+
+interface Props {
+  searchParams: DataTableSearchParams;
+}
+
+const fmt = (n: number) => `$${n.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+
+export default async function RetentionsView({ searchParams }: Props) {
+  const [{ data, total }, summary, taxTypeOptions] = await Promise.all([
+    getRetentionsPaginated(searchParams),
+    getRetentionsSummary(),
+    getRetentionTypeOptions(),
+  ]);
+
+  return (
+    <div className="space-y-4">
+      {summary.byTaxType.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total retenido</CardDescription>
+              <CardTitle className="text-xl font-mono text-amber-600">
+                {fmt(summary.totalAmount)}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          {summary.byTaxType.slice(0, 3).map((g) => (
+            <Card key={g.taxTypeId}>
+              <CardHeader className="pb-2">
+                <CardDescription>{g.name}</CardDescription>
+                <CardTitle className="text-xl font-mono">{fmt(g.total)}</CardTitle>
+                <Badge variant="outline" className="w-fit mt-1">
+                  {g.count} comprobante{g.count === 1 ? '' : 's'}
+                </Badge>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Retenciones aplicadas</CardTitle>
+          <CardDescription>
+            Lista de retenciones en órdenes de pago. Cada línea genera un comprobante
+            numerado al confirmar la OP. Click en el N° de certificado descarga el PDF.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RetentionsDataTable
+            data={data}
+            totalRows={total}
+            searchParams={searchParams as any}
+            taxTypeOptions={taxTypeOptions}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/treasury/features/retentions/components/_RetentionsDataTable.tsx
+++ b/src/modules/treasury/features/retentions/components/_RetentionsDataTable.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { DataTable } from '@/shared/components/common/DataTable';
+import type { DataTableFacetedFilterConfig } from '@/shared/components/common/DataTable/types';
+import { PAYMENT_ORDER_STATUS_LABELS } from '@/modules/treasury/shared/validators';
+import { retentionColumns } from './columns';
+import { getAllRetentionsForExport, type RetentionRow } from '../actions.server';
+import { format } from 'date-fns';
+
+interface Props {
+  data: RetentionRow[];
+  totalRows: number;
+  searchParams: Record<string, string | undefined>;
+  taxTypeOptions: { id: string; code: string; name: string }[];
+}
+
+export function RetentionsDataTable({ data, totalRows, searchParams, taxTypeOptions }: Props) {
+  const filterConfig: DataTableFacetedFilterConfig[] = [
+    { columnId: 'payment_order_date', title: 'Fecha', type: 'dateRange' },
+    { columnId: 'supplier', title: 'Proveedor', type: 'text' },
+    {
+      columnId: 'tax_type',
+      title: 'Tipo',
+      type: 'faceted',
+      options: taxTypeOptions.map((t) => ({ label: t.name, value: t.id })),
+    },
+    {
+      columnId: 'payment_order_status',
+      title: 'Estado OP',
+      type: 'faceted',
+      options: Object.entries(PAYMENT_ORDER_STATUS_LABELS).map(([value, label]) => ({
+        label,
+        value,
+      })),
+    },
+  ];
+
+  return (
+    <DataTable
+      columns={retentionColumns as any}
+      data={data as any}
+      totalRows={totalRows}
+      searchParams={searchParams}
+      searchPlaceholder="Buscar por OP, proveedor o N° de certificado..."
+      facetedFilters={filterConfig}
+      tableId="retentions"
+      showFilterToggle
+      exportConfig={{
+        fetchAllData: () =>
+          getAllRetentionsForExport(searchParams).then(
+            (rows) => rows as unknown as Record<string, unknown>[]
+          ),
+        options: {
+          filename: 'retenciones',
+          sheetName: 'Retenciones',
+          title: 'Retenciones aplicadas',
+          includeDate: true,
+        },
+        formatters: {
+          payment_order_date: (v) =>
+            v ? format(new Date(v as string), 'dd/MM/yyyy') : '',
+          payment_order_status: (v) =>
+            (PAYMENT_ORDER_STATUS_LABELS as Record<string, string>)[v as string] ?? String(v ?? ''),
+          tax_type_name: (_v, row) => {
+            const r = row as unknown as RetentionRow;
+            return r.tax_type_jurisdiction
+              ? `${r.tax_type_name} (${r.tax_type_jurisdiction})`
+              : r.tax_type_name;
+          },
+          rate: (v) => `${v}%`,
+        },
+        excludeColumns: ['notes'],
+      }}
+    />
+  );
+}

--- a/src/modules/treasury/features/retentions/components/columns.tsx
+++ b/src/modules/treasury/features/retentions/components/columns.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import Link from 'next/link';
+import { Badge } from '@/shared/components/ui/badge';
+import { format } from 'date-fns';
+import { ExternalLink } from 'lucide-react';
+import { PAYMENT_ORDER_STATUS_LABELS } from '@/modules/treasury/shared/validators';
+import type { RetentionRow } from '../actions.server';
+
+const fmt = (n: number) => `$${n.toLocaleString('es-AR', { minimumFractionDigits: 2 })}`;
+
+export const retentionColumns: ColumnDef<RetentionRow>[] = [
+  {
+    accessorKey: 'payment_order_date',
+    header: 'Fecha',
+    cell: ({ row }) => format(new Date(row.original.payment_order_date), 'dd/MM/yyyy'),
+  },
+  {
+    accessorKey: 'payment_order_full_number',
+    header: 'OP',
+    cell: ({ row }) => (
+      <Link
+        href={`/dashboard/treasury/payment-orders/${row.original.payment_order_id}`}
+        className="font-mono text-primary hover:underline inline-flex items-center gap-1"
+      >
+        {row.original.payment_order_full_number}
+        <ExternalLink className="size-3" />
+      </Link>
+    ),
+  },
+  {
+    accessorKey: 'supplier',
+    header: 'Proveedor',
+    cell: ({ row }) => (
+      <div>
+        <div className="font-medium">{row.original.supplier}</div>
+        {row.original.supplier_tax_id && (
+          <div className="text-xs text-muted-foreground font-mono">
+            {row.original.supplier_tax_id}
+          </div>
+        )}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'tax_type_name',
+    header: 'Tipo',
+    cell: ({ row }) => (
+      <div>
+        <div className="text-sm">{row.original.tax_type_name}</div>
+        {row.original.tax_type_jurisdiction && (
+          <div className="text-xs text-muted-foreground">
+            {row.original.tax_type_jurisdiction}
+          </div>
+        )}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'base_amount',
+    header: 'Base',
+    cell: ({ row }) => (
+      <span className="font-mono text-sm">{fmt(row.original.base_amount)}</span>
+    ),
+  },
+  {
+    accessorKey: 'rate',
+    header: 'Alícuota',
+    cell: ({ row }) => <span className="font-mono text-sm">{row.original.rate}%</span>,
+  },
+  {
+    accessorKey: 'amount',
+    header: () => <div className="text-right">Monto</div>,
+    cell: ({ row }) => (
+      <div className="text-right font-mono font-semibold text-amber-600">
+        {fmt(row.original.amount)}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'certificate_number',
+    header: 'Certificado',
+    cell: ({ row }) =>
+      row.original.certificate_number ? (
+        <a
+          href={`/api/retention-certificates/${row.original.id}/pdf`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline font-mono text-xs"
+        >
+          {row.original.certificate_number}
+        </a>
+      ) : (
+        <span className="text-xs text-muted-foreground">Pendiente</span>
+      ),
+  },
+  {
+    accessorKey: 'payment_order_status',
+    header: 'Estado OP',
+    cell: ({ row }) => {
+      const status = row.original
+        .payment_order_status as keyof typeof PAYMENT_ORDER_STATUS_LABELS;
+      const variant =
+        status === 'PAID'
+          ? 'success'
+          : status === 'CONFIRMED'
+            ? 'default'
+            : status === 'CANCELLED'
+              ? 'destructive'
+              : 'outline';
+      return <Badge variant={variant as any}>{PAYMENT_ORDER_STATUS_LABELS[status]}</Badge>;
+    },
+  },
+];

--- a/src/modules/treasury/shared/payment-order-validators.ts
+++ b/src/modules/treasury/shared/payment-order-validators.ts
@@ -54,6 +54,15 @@ export const paymentOrderPaymentSchema = z
   });
 export type PaymentOrderPaymentFormData = z.infer<typeof paymentOrderPaymentSchema>;
 
+export const paymentOrderRetentionSchema = z.object({
+  tax_type_id: z.string().uuid('Seleccione un tipo de retención'),
+  base_amount: z.coerce.number().min(0, 'Base no puede ser negativa'),
+  rate: z.coerce.number().min(0).max(100, 'Alícuota fuera de rango'),
+  amount: z.coerce.number().min(0, 'Monto no puede ser negativo'),
+  notes: z.string().optional().nullable(),
+});
+export type PaymentOrderRetentionFormData = z.infer<typeof paymentOrderRetentionSchema>;
+
 export const paymentOrderSchema = z
   .object({
     supplier_id: z.string().uuid().optional().nullable(),
@@ -66,13 +75,22 @@ export const paymentOrderSchema = z
     notes: z.string().max(1000).optional().nullable(),
     items: z.array(paymentOrderItemSchema).min(1, 'Al menos un ítem'),
     payments: z.array(paymentOrderPaymentSchema).min(1, 'Al menos un pago'),
+    retentions: z.array(paymentOrderRetentionSchema).optional().default([]),
   })
   .refine(
     (data) => {
       const itemsTotal = data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
       const paymentsTotal = data.payments.reduce((acc, p) => acc + parseFloat(p.amount), 0);
-      return Math.abs(itemsTotal - paymentsTotal) < 0.01;
+      const retentionsTotal = (data.retentions ?? []).reduce(
+        (acc, r) => acc + (Number(r.amount) || 0),
+        0
+      );
+      // items_total - retentions_total === payments_total (neto a pagar).
+      return Math.abs(itemsTotal - retentionsTotal - paymentsTotal) < 0.01;
     },
-    { message: 'El total de ítems debe coincidir con el total de pagos' }
+    {
+      message:
+        'El total de ítems menos las retenciones debe coincidir con el total de pagos',
+    }
   );
 export type PaymentOrderFormData = z.infer<typeof paymentOrderSchema>;

--- a/supabase/migrations/20260506164927_add_retentions_and_perceptions.sql
+++ b/supabase/migrations/20260506164927_add_retentions_and_perceptions.sql
@@ -1,0 +1,153 @@
+-- ================================================================
+-- RETENCIONES Y PERCEPCIONES (Fase 1 — schema)
+-- ================================================================
+-- Modelo de datos:
+--
+-- tax_types: catálogo configurable por empresa de tipos de impuesto
+--   (RETENTION o PERCEPTION). Define alícuota default, base de cálculo
+--   y mínimo no imponible. Ejemplos:
+--     - RET_GANANCIAS, RET_IVA, RET_IIBB_NEU, RET_SUSS
+--     - PERC_IVA, PERC_IIBB_NEU
+--
+-- purchase_invoice_perceptions: líneas de percepciones cargadas en
+--   cada factura de compra (lo que el proveedor cobra).
+--
+-- payment_order_retentions: líneas de retenciones aplicadas al pagar
+--   (lo que el comprador retiene). Guardan certificate_number para el
+--   comprobante.
+--
+-- retention_certificate_sequences: numeración secuencial de
+--   comprobantes por (company, tax_type) para emitir certificados.
+--
+-- payment_orders gana retentions_total y net_to_pay (derivados pero
+--   persistidos para queries simples y cuadre).
+-- ================================================================
+
+BEGIN;
+
+-- ============================================================
+-- ENUMS
+-- ============================================================
+
+DO $$ BEGIN
+  CREATE TYPE "tax_kind" AS ENUM ('RETENTION', 'PERCEPTION');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "tax_scope" AS ENUM ('NATIONAL', 'PROVINCIAL', 'MUNICIPAL');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "tax_calculation_base" AS ENUM ('NET', 'TOTAL', 'VAT');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ============================================================
+-- CATÁLOGO: TAX_TYPES
+-- ============================================================
+-- code: identificador estable por empresa (ej. 'RET_IIBB_NEU').
+-- jurisdiction: provincia/municipio cuando aplica (NULL para nacionales).
+-- default_rate: alícuota % a aplicar por defecto (editable en cada uso).
+-- min_taxable_amount: NULL = sin mínimo. Si se setea, no se retiene/percibe
+--   cuando la base está por debajo (la app valida; la DB solo guarda).
+-- calculation_base: sobre qué se calcula (neto, total, IVA).
+
+CREATE TABLE IF NOT EXISTS "tax_types" (
+  "id"                 uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  "company_id"         uuid NOT NULL REFERENCES "company"("id") ON DELETE CASCADE,
+  "code"               text NOT NULL,
+  "name"               text NOT NULL,
+  "kind"               "tax_kind" NOT NULL,
+  "scope"              "tax_scope" NOT NULL DEFAULT 'NATIONAL',
+  "jurisdiction"       text,
+  "calculation_base"   "tax_calculation_base" NOT NULL DEFAULT 'NET',
+  "default_rate"       numeric(8, 4) NOT NULL DEFAULT 0,
+  "min_taxable_amount" numeric(15, 2),
+  "is_active"          boolean NOT NULL DEFAULT true,
+  "notes"              text,
+  "created_at"         timestamptz NOT NULL DEFAULT now(),
+  "updated_at"         timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "tax_types_company_code_unique" UNIQUE ("company_id", "code")
+);
+
+CREATE INDEX IF NOT EXISTS "tax_types_company_kind_idx"
+  ON "tax_types" ("company_id", "kind") WHERE "is_active" = true;
+
+-- ============================================================
+-- PERCEPCIONES EN FACTURAS DE COMPRA
+-- ============================================================
+-- Línea por percepción aplicada en una factura recibida. El total de
+-- la factura debe igualar subtotal + vat_amount + sum(perceptions.amount).
+-- Se cachea el agregado en purchase_invoices.other_taxes.
+
+CREATE TABLE IF NOT EXISTS "purchase_invoice_perceptions" (
+  "id"          uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  "invoice_id"  uuid NOT NULL REFERENCES "purchase_invoices"("id") ON DELETE CASCADE,
+  "tax_type_id" uuid NOT NULL REFERENCES "tax_types"("id") ON DELETE RESTRICT,
+  "base_amount" numeric(15, 2) NOT NULL,
+  "rate"        numeric(8, 4) NOT NULL,
+  "amount"      numeric(15, 2) NOT NULL,
+  "notes"       text,
+  "created_at"  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "purchase_invoice_perceptions_invoice_idx"
+  ON "purchase_invoice_perceptions" ("invoice_id");
+CREATE INDEX IF NOT EXISTS "purchase_invoice_perceptions_tax_type_idx"
+  ON "purchase_invoice_perceptions" ("tax_type_id");
+
+-- ============================================================
+-- RETENCIONES EN ÓRDENES DE PAGO
+-- ============================================================
+-- Línea por retención aplicada al pagar. certificate_number se asigna
+-- al confirmar la OP (Fase 5) usando retention_certificate_sequences.
+
+CREATE TABLE IF NOT EXISTS "payment_order_retentions" (
+  "id"                 uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  "payment_order_id"   uuid NOT NULL REFERENCES "payment_orders"("id") ON DELETE CASCADE,
+  "tax_type_id"        uuid NOT NULL REFERENCES "tax_types"("id") ON DELETE RESTRICT,
+  "base_amount"        numeric(15, 2) NOT NULL,
+  "rate"               numeric(8, 4) NOT NULL,
+  "amount"             numeric(15, 2) NOT NULL,
+  "certificate_number" text,
+  "certificate_url"    text,
+  "notes"              text,
+  "created_at"         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "payment_order_retentions_order_idx"
+  ON "payment_order_retentions" ("payment_order_id");
+CREATE INDEX IF NOT EXISTS "payment_order_retentions_tax_type_idx"
+  ON "payment_order_retentions" ("tax_type_id");
+
+-- ============================================================
+-- NUMERACIÓN DE COMPROBANTES DE RETENCIÓN
+-- ============================================================
+-- Una secuencia por (company, tax_type). Al confirmar la OP se hace
+-- UPDATE ... RETURNING last_number + 1 para evitar race conditions.
+
+CREATE TABLE IF NOT EXISTS "retention_certificate_sequences" (
+  "company_id"  uuid NOT NULL REFERENCES "company"("id") ON DELETE CASCADE,
+  "tax_type_id" uuid NOT NULL REFERENCES "tax_types"("id") ON DELETE CASCADE,
+  "last_number" integer NOT NULL DEFAULT 0,
+  "updated_at"  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("company_id", "tax_type_id")
+);
+
+-- ============================================================
+-- EXTENSIÓN DE payment_orders
+-- ============================================================
+-- retentions_total: suma de payment_order_retentions.amount (cache).
+-- net_to_pay: total_amount - retentions_total (lo que sale efectivamente
+--   de caja/banco al proveedor). Se recalcula al guardar.
+-- La cuenta corriente del proveedor sigue cancelándose por total_amount.
+
+ALTER TABLE "payment_orders"
+  ADD COLUMN IF NOT EXISTS "retentions_total" numeric(15, 2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "net_to_pay"       numeric(15, 2);
+
+-- Backfill: las OPs existentes no tienen retenciones, net_to_pay = total_amount.
+UPDATE "payment_orders"
+SET "net_to_pay" = "total_amount"
+WHERE "net_to_pay" IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Plan completo de retenciones (sobre OP) y percepciones (en facturas de compra) con catálogo configurable, comprobantes numerados y vista para cierre fiscal mensual.

Schema (1 migración):
- tax_types (catálogo configurable por empresa, kind RETENTION|PERCEPTION)
- purchase_invoice_perceptions (líneas en facturas)
- payment_order_retentions (líneas en OPs)
- retention_certificate_sequences (numeración por tipo)
- payment_orders.retentions_total + net_to_pay

Configuración:
- Tab "Impuestos" en /dashboard/settings con CRUD de tax_types (sub-tabs Retenciones / Percepciones, alícuota default, base de cálculo, mínimo no imponible, jurisdicción).

Percepciones en factura de compra:
- Sección "Percepciones" en el form con autocompletado de base según calculation_base. Total = subtotal + IVA + percepciones.
- Card "Percepciones" en el detalle de factura.

Retenciones en OP:
- Sección "Retenciones" en el form con base sugerida = items_total y cálculo automático editable. Cuadre: items - retenciones = pagos.
- En confirmPaymentOrder: numeración secuencial atómica por (company, tax_type) y persistencia de certificate_number.
- cash_movements/bank_movements salen por net_to_pay; cuenta corriente del proveedor cancela total_amount.
- PDF de OP con sección de retenciones y resumen Total/Retenciones/Neto.

Comprobantes de retención:
- Plantilla A4 con datos formales (retenido, régimen, base, alícuota, monto en palabras, firma del agente).
- /api/retention-certificates/[id]/pdf protegido por company.
- Adjuntos al mail al marcar OP como pagada (uno por retención).

Vista de cierre mensual:
- /dashboard/treasury?tab=retentions con cards de resumen, DataTable con filtros (fecha, tipo, proveedor, estado OP) y descarga de certificados PDF inline.
- Botón Excel reusa la funcionalidad estándar de DataTable.

Mejoras tangenciales:
- Retenciones y Saldos Pendientes ahora son tabs nativas en Tesorería (las URLs viejas redirigen al tab correspondiente).
- Fix RetentionCertificateTemplate: 'border: 1' shorthand no soportado por @react-pdf, reemplazado por borderWidth+borderStyle.
- Fix retention_certificate_sequences: removido @unique redundante en tax_type_id que rompía el upsert con ON CONFLICT.