### PR TITLE
feat(purchasing): módulo de gastos con integración a ordenes de pago

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,14 @@ enum training_status {
   Publicado
 }
 
+enum expense_status {
+  DRAFT
+  CONFIRMED
+  PARTIAL_PAID
+  PAID
+  CANCELLED
+}
+
 enum type_of_maintenance_ENUM {
   Correctivo
   Preventivo
@@ -398,6 +406,10 @@ model company {
   // Retenciones y percepciones
   tax_types                       tax_types[]
   retention_certificate_sequences retention_certificate_sequences[]
+
+  // Gastos
+  expense_categories expense_categories[]
+  expenses           expenses[]
 }
 
 model pdf_settings {
@@ -1722,6 +1734,7 @@ model suppliers {
   payment_orders    payment_orders[]
   checks            checks[]
   payment_methods   supplier_payment_methods[]
+  expenses          expenses[]
 
   @@unique([company_id, code])
   @@unique([company_id, tax_id])
@@ -2416,13 +2429,16 @@ model payment_order_items {
   id               String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   payment_order_id String  @db.Uuid
   invoice_id       String? @db.Uuid
+  expense_id       String? @db.Uuid
   amount           Decimal @db.Decimal(15, 2)
 
   payment_order payment_orders     @relation(fields: [payment_order_id], references: [id], onDelete: Cascade)
   invoice       purchase_invoices? @relation(fields: [invoice_id], references: [id])
+  expense       expenses?          @relation(fields: [expense_id], references: [id])
 
   @@index([payment_order_id])
   @@index([invoice_id])
+  @@index([expense_id])
 }
 
 model payment_order_payments {
@@ -2492,4 +2508,68 @@ model checks {
 
   @@index([company_id, type, status])
   @@index([company_id, due_date])
+}
+
+// ============================================================
+// GASTOS
+// ============================================================
+
+model expense_categories {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  company_id  String   @db.Uuid
+  name        String
+  description String?
+  is_active   Boolean  @default(true)
+  created_at  DateTime @default(now()) @db.Timestamptz
+  updated_at  DateTime @default(now()) @updatedAt @db.Timestamptz
+
+  company  company    @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  expenses expenses[]
+
+  @@unique([company_id, name])
+  @@index([company_id])
+}
+
+model expenses {
+  id          String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  company_id  String         @db.Uuid
+  number      Int
+  full_number String
+  description String
+  amount      Decimal        @db.Decimal(15, 2)
+  date        DateTime       @db.Date
+  due_date    DateTime?      @db.Date
+  status      expense_status @default(DRAFT)
+  notes       String?
+  category_id String         @db.Uuid
+  supplier_id String?        @db.Uuid
+  created_by  String
+  created_at  DateTime       @default(now()) @db.Timestamptz
+  updated_at  DateTime       @default(now()) @updatedAt @db.Timestamptz
+
+  company             company              @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  category            expense_categories   @relation(fields: [category_id], references: [id])
+  supplier            suppliers?           @relation(fields: [supplier_id], references: [id])
+  expense_attachments expense_attachments[]
+  payment_order_items payment_order_items[]
+
+  @@unique([company_id, number])
+  @@index([company_id])
+  @@index([category_id])
+  @@index([supplier_id])
+  @@index([status])
+}
+
+model expense_attachments {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  expense_id String  @db.Uuid
+  file_name  String
+  file_key   String
+  file_size  Int?
+  mime_type  String?
+  created_at DateTime @default(now()) @db.Timestamptz
+
+  expense expenses @relation(fields: [expense_id], references: [id], onDelete: Cascade)
+
+  @@index([expense_id])
 }

--- a/src/app/api/payment-orders/[id]/pdf/route.ts
+++ b/src/app/api/payment-orders/[id]/pdf/route.ts
@@ -52,6 +52,15 @@ export async function GET(
                 total: true,
               },
             },
+            expense: {
+              select: {
+                full_number: true,
+                description: true,
+                date: true,
+                due_date: true,
+                amount: true,
+              },
+            },
           },
         },
         payments: {
@@ -143,6 +152,16 @@ export async function GET(
           issueDate: it.invoice!.issue_date,
           dueDate: it.invoice!.due_date,
           total: Number(it.invoice!.total),
+          appliedAmount: Number(it.amount),
+        })),
+      expenses: order.items
+        .filter((it) => it.expense)
+        .map((it) => ({
+          fullNumber: it.expense!.full_number,
+          description: it.expense!.description,
+          date: it.expense!.date,
+          dueDate: it.expense!.due_date,
+          total: Number(it.expense!.amount),
           appliedAmount: Number(it.amount),
         })),
       payments: order.payments.map((p) => ({

--- a/src/app/dashboard/purchasing/page.tsx
+++ b/src/app/dashboard/purchasing/page.tsx
@@ -2,6 +2,7 @@ import PurchaseOrdersList from '@/modules/purchasing/features/purchase-orders/li
 import InvoicesList from '@/modules/purchasing/features/invoices/list/components/InvoicesList';
 import ReceivingNotesList from '@/modules/purchasing/features/receiving-notes/list/components/ReceivingNotesList';
 import SuppliersList from '@/modules/suppliers/features/list/components/SuppliersList';
+import { ExpensesList } from '@/modules/purchasing/features/expenses';
 import PageTableSkeleton from '@/shared/components/common/Skeletons/PageTableSkeleton';
 import { buttonVariants } from '@/shared/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
@@ -10,7 +11,7 @@ import Link from 'next/link';
 import { Suspense } from 'react';
 import type { DataTableSearchParams } from '@/shared/components/common/DataTable';
 
-const VALID_TABS = ['orders', 'invoices', 'receiving', 'suppliers'] as const;
+const VALID_TABS = ['orders', 'invoices', 'receiving', 'suppliers', 'expenses'] as const;
 type PurchasingTab = (typeof VALID_TABS)[number];
 
 export default async function PurchasingPage({
@@ -31,6 +32,7 @@ export default async function PurchasingPage({
           <UrlTabsTrigger value="invoices">Facturas</UrlTabsTrigger>
           <UrlTabsTrigger value="receiving">Remitos de recepción</UrlTabsTrigger>
           <UrlTabsTrigger value="suppliers">Proveedores</UrlTabsTrigger>
+          <UrlTabsTrigger value="expenses">Gastos</UrlTabsTrigger>
         </UrlTabsList>
 
         <UrlTabsContent value="orders">
@@ -97,6 +99,20 @@ export default async function PurchasingPage({
             </CardHeader>
             <CardContent>
               <SuppliersList searchParams={resolved} />
+            </CardContent>
+          </Card>
+        </UrlTabsContent>
+
+        <UrlTabsContent value="expenses">
+          <Card>
+            <CardHeader>
+              <CardTitle>Gastos</CardTitle>
+              <CardDescription>Gestión de gastos operativos de la empresa</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Suspense fallback={<PageTableSkeleton />}>
+                <ExpensesList searchParams={resolved} />
+              </Suspense>
             </CardContent>
           </Card>
         </UrlTabsContent>

--- a/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
+++ b/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
@@ -28,7 +28,8 @@ export default async function EditPaymentOrderPage({
     notes: order.notes,
     items: order.items.map((i) => ({
       invoice_id: i.invoice_id,
-      invoice_label: i.invoice?.full_number ?? null,
+      expense_id: i.expense_id ?? null,
+      invoice_label: i.invoice?.full_number ?? i.expense?.full_number ?? null,
       amount: i.amount.toFixed(2),
     })),
     payments: order.payments.map((p) => ({

--- a/src/modules/purchasing/features/expenses/actions.server.ts
+++ b/src/modules/purchasing/features/expenses/actions.server.ts
@@ -1,0 +1,703 @@
+'use server';
+
+import { prisma } from '@/shared/lib/prisma';
+import { getActionContext } from '@/shared/lib/server-action-context';
+import { requirePermission } from '@/shared/lib/permissions';
+import { fetchCurrentUser } from '@/shared/actions/auth';
+import { revalidatePath } from 'next/cache';
+import type { DataTableSearchParams } from '@/shared/components/common/DataTable/types';
+import {
+  parseSearchParams,
+  stateToPrismaParams,
+  buildFiltersWhere,
+  buildTextFiltersWhere,
+  buildDateRangeFiltersWhere,
+} from '@/shared/components/common/DataTable/helpers';
+import type { ExpenseFormInput, ExpenseCategoryFormInput } from './validators';
+
+// ============================================
+// HELPERS
+// ============================================
+
+const REVALIDATE_PATH = '/dashboard/purchasing';
+
+/**
+ * Normaliza una fecha @db.Date (medianoche UTC) a mediodia UTC
+ * para evitar desplazamiento de dia por timezone del cliente.
+ */
+function normalizeDbDate(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(12, 0, 0, 0);
+  return d;
+}
+
+function normalizeDbDateNullable(date: Date | null): Date | null {
+  return date ? normalizeDbDate(date) : null;
+}
+
+// ============================================
+// CATEGORIAS DE GASTOS
+// ============================================
+
+/**
+ * Obtiene las categorias de gastos activas de la empresa (para selects)
+ */
+export async function getExpenseCategories() {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  return prisma.expense_categories.findMany({
+    where: { company_id: companyId, is_active: true },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      is_active: true,
+    },
+    orderBy: { name: 'asc' },
+  });
+}
+
+/**
+ * Obtiene todas las categorias (incluye inactivas + count de gastos) para gestion
+ */
+export async function getAllExpenseCategories() {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  return prisma.expense_categories.findMany({
+    where: { company_id: companyId },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      is_active: true,
+      _count: { select: { expenses: true } },
+    },
+    orderBy: { name: 'asc' },
+  });
+}
+
+/**
+ * Crea una nueva categoria de gastos
+ */
+export async function createExpenseCategory(data: ExpenseCategoryFormInput) {
+  await requirePermission('compras.gastos.create');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const category = await prisma.expense_categories.create({
+      data: {
+        company_id: companyId,
+        name: data.name,
+        description: data.description || null,
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true, id: category.id };
+  } catch (error) {
+    if ((error as any)?.code === 'P2002') {
+      throw new Error('Ya existe una categoria con ese nombre');
+    }
+    console.error('Error al crear categoria de gasto:', error);
+    throw new Error('Error al crear categoria de gasto');
+  }
+}
+
+/**
+ * Actualiza una categoria de gastos
+ */
+export async function updateExpenseCategory(id: string, data: ExpenseCategoryFormInput) {
+  await requirePermission('compras.gastos.update');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const result = await prisma.expense_categories.updateMany({
+      where: { id, company_id: companyId },
+      data: {
+        name: data.name,
+        description: data.description || null,
+      },
+    });
+
+    if (result.count === 0) throw new Error('Categoria no encontrada');
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if ((error as any)?.code === 'P2002') {
+      throw new Error('Ya existe una categoria con ese nombre');
+    }
+    if (error instanceof Error) throw error;
+    console.error('Error al actualizar categoria de gasto:', error);
+    throw new Error('Error al actualizar categoria de gasto');
+  }
+}
+
+/**
+ * Activa/desactiva una categoria de gastos
+ */
+export async function toggleExpenseCategory(id: string) {
+  await requirePermission('compras.gastos.update');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const category = await prisma.expense_categories.findFirst({
+      where: { id, company_id: companyId },
+      select: { is_active: true },
+    });
+
+    if (!category) throw new Error('Categoria no encontrada');
+
+    await prisma.expense_categories.updateMany({
+      where: { id, company_id: companyId },
+      data: { is_active: !category.is_active },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al cambiar estado de categoria:', error);
+    throw new Error('Error al cambiar estado de categoria');
+  }
+}
+
+// ============================================
+// GASTOS - CRUD
+// ============================================
+
+/**
+ * Obtiene gastos con paginacion server-side para DataTable
+ */
+export async function getExpensesPaginated(searchParams: DataTableSearchParams) {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return { data: [], total: 0 };
+
+  try {
+    const state = parseSearchParams(searchParams);
+    const { skip, take } = stateToPrismaParams(state);
+
+    const where: Record<string, unknown> = { company_id: companyId };
+
+    // Global search
+    if (state.search) {
+      where.OR = [
+        { full_number: { contains: state.search, mode: 'insensitive' } },
+        { description: { contains: state.search, mode: 'insensitive' } },
+        { supplier: { business_name: { contains: state.search, mode: 'insensitive' } } },
+        { category: { name: { contains: state.search, mode: 'insensitive' } } },
+      ];
+    }
+
+    // Faceted filters: status, category_id
+    const filtersWhere = buildFiltersWhere(state.filters, {
+      status: 'status',
+      category_id: 'category_id',
+    });
+    Object.assign(where, filtersWhere);
+
+    // Text filters: full_number
+    const textWhere = buildTextFiltersWhere(state.filters, ['full_number']);
+    Object.assign(where, textWhere);
+
+    // Text filter for supplier (nested relation)
+    const supplierFilter = state.filters.supplier?.[0];
+    if (supplierFilter) {
+      where.supplier = {
+        business_name: { contains: supplierFilter, mode: 'insensitive' },
+      };
+    }
+
+    // Date range filters: date, due_date
+    const dateWhere = buildDateRangeFiltersWhere(state.filters, ['date', 'due_date']);
+    Object.assign(where, dateWhere);
+
+    // Sorting
+    const sortByField = state.sortBy;
+    let orderBy: any;
+
+    if (sortByField === 'supplier' || sortByField === 'supplier_name') {
+      orderBy = { supplier: { business_name: state.sortOrder } };
+    } else if (sortByField === 'category' || sortByField === 'category_name') {
+      orderBy = { category: { name: state.sortOrder } };
+    } else if (sortByField) {
+      orderBy = { [sortByField]: state.sortOrder };
+    } else {
+      orderBy = { number: 'desc' as const };
+    }
+
+    const [data, total] = await Promise.all([
+      prisma.expenses.findMany({
+        where: where as any,
+        select: {
+          id: true,
+          number: true,
+          full_number: true,
+          description: true,
+          amount: true,
+          date: true,
+          due_date: true,
+          status: true,
+          created_at: true,
+          category: {
+            select: { id: true, name: true },
+          },
+          supplier: {
+            select: { id: true, business_name: true },
+          },
+          _count: {
+            select: { expense_attachments: true, payment_order_items: true },
+          },
+        },
+        orderBy,
+        skip,
+        take,
+      }),
+      prisma.expenses.count({ where: where as any }),
+    ]);
+
+    return {
+      data: data.map((expense) => ({
+        ...expense,
+        amount: Number(expense.amount),
+        date: normalizeDbDate(expense.date),
+        due_date: normalizeDbDateNullable(expense.due_date),
+      })),
+      total,
+    };
+  } catch (error) {
+    console.error('Error al obtener gastos paginados:', error);
+    return { data: [], total: 0 };
+  }
+}
+
+/**
+ * Facet counts por status y category_id para filtros faceted del DataTable
+ */
+export async function getExpenseFacetCounts(): Promise<Record<string, { value: string; count: number }[]>> {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return {};
+
+  try {
+    const [statusGroups, categoryGroups] = await Promise.all([
+      prisma.expenses.groupBy({
+        by: ['status'],
+        where: { company_id: companyId },
+        _count: true,
+      }),
+      prisma.expenses.groupBy({
+        by: ['category_id'],
+        where: { company_id: companyId },
+        _count: true,
+      }),
+    ]);
+
+    return {
+      status: statusGroups.map((g) => ({ value: g.status, count: g._count })),
+      category_id: categoryGroups.map((g) => ({ value: g.category_id, count: g._count })),
+    };
+  } catch (error) {
+    return {};
+  }
+}
+
+/**
+ * Obtiene el detalle de un gasto con adjuntos e items de OP
+ */
+export async function getExpenseById(id: string) {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const expense = await prisma.expenses.findFirst({
+      where: { id, company_id: companyId },
+      select: {
+        id: true,
+        number: true,
+        full_number: true,
+        description: true,
+        amount: true,
+        date: true,
+        due_date: true,
+        status: true,
+        notes: true,
+        created_by: true,
+        created_at: true,
+        category: {
+          select: { id: true, name: true },
+        },
+        supplier: {
+          select: { id: true, business_name: true, tax_id: true },
+        },
+        expense_attachments: {
+          select: {
+            id: true,
+            file_name: true,
+            file_size: true,
+            mime_type: true,
+            created_at: true,
+          },
+          orderBy: { created_at: 'desc' },
+        },
+        payment_order_items: {
+          select: {
+            id: true,
+            amount: true,
+            payment_order: {
+              select: {
+                id: true,
+                full_number: true,
+                date: true,
+                status: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!expense) throw new Error('Gasto no encontrado');
+
+    // Calcular monto pagado (solo items de OPs confirmadas/pagadas)
+    const paidAmount = expense.payment_order_items
+      .filter((item) => item.payment_order.status === 'CONFIRMED')
+      .reduce((sum, item) => sum + Number(item.amount), 0);
+
+    return {
+      ...expense,
+      amount: Number(expense.amount),
+      date: normalizeDbDate(expense.date),
+      due_date: normalizeDbDateNullable(expense.due_date),
+      paidAmount,
+      pendingAmount: Number(expense.amount) - paidAmount,
+      payment_order_items: expense.payment_order_items.map((item) => ({
+        ...item,
+        amount: Number(item.amount),
+      })),
+    };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al obtener gasto:', error);
+    throw new Error('Error al obtener gasto');
+  }
+}
+
+/**
+ * Crea un nuevo gasto (borrador) con numeracion secuencial GTO-XXXXX
+ */
+export async function createExpense(data: ExpenseFormInput) {
+  await requirePermission('compras.gastos.create');
+  const user = await fetchCurrentUser();
+  if (!user?.id) throw new Error('No autenticado');
+
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const lastExpense = await prisma.expenses.findFirst({
+      where: { company_id: companyId },
+      orderBy: { number: 'desc' },
+      select: { number: true },
+    });
+
+    const nextNumber = (lastExpense?.number ?? 0) + 1;
+    const fullNumber = `GTO-${String(nextNumber).padStart(5, '0')}`;
+
+    const expense = await prisma.expenses.create({
+      data: {
+        company_id: companyId,
+        number: nextNumber,
+        full_number: fullNumber,
+        description: data.description,
+        amount: parseFloat(data.amount),
+        date: data.date,
+        due_date: data.due_date || null,
+        category_id: data.category_id,
+        supplier_id: data.supplier_id || null,
+        notes: data.notes || null,
+        status: 'DRAFT',
+        created_by: user.id,
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true, id: expense.id };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al crear gasto:', error);
+    throw new Error('Error al crear gasto');
+  }
+}
+
+/**
+ * Actualiza un gasto (solo si esta en DRAFT)
+ */
+export async function updateExpense(id: string, data: ExpenseFormInput) {
+  await requirePermission('compras.gastos.update');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const existing = await prisma.expenses.findFirst({
+      where: { id, company_id: companyId, status: 'DRAFT' },
+      select: { id: true },
+    });
+
+    if (!existing) throw new Error('Gasto no encontrado o no esta en estado borrador');
+
+    await prisma.expenses.update({
+      where: { id },
+      data: {
+        description: data.description,
+        amount: parseFloat(data.amount),
+        date: data.date,
+        due_date: data.due_date || null,
+        category_id: data.category_id,
+        supplier_id: data.supplier_id || null,
+        notes: data.notes || null,
+      },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al actualizar gasto:', error);
+    throw new Error('Error al actualizar gasto');
+  }
+}
+
+/**
+ * Confirma un gasto: DRAFT -> CONFIRMED
+ */
+export async function confirmExpense(id: string) {
+  await requirePermission('compras.gastos.confirm');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const expense = await prisma.expenses.findFirst({
+      where: { id, company_id: companyId, status: 'DRAFT' },
+      select: { id: true },
+    });
+
+    if (!expense) throw new Error('Gasto no encontrado o ya confirmado');
+
+    await prisma.expenses.update({
+      where: { id },
+      data: { status: 'CONFIRMED' },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al confirmar gasto:', error);
+    throw new Error('Error al confirmar gasto');
+  }
+}
+
+/**
+ * Cancela un gasto (solo DRAFT o CONFIRMED sin pagos confirmados)
+ */
+export async function cancelExpense(id: string) {
+  await requirePermission('compras.gastos.delete');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const expense = await prisma.expenses.findFirst({
+      where: {
+        id,
+        company_id: companyId,
+        status: { in: ['DRAFT', 'CONFIRMED'] },
+      },
+      select: {
+        id: true,
+        status: true,
+        payment_order_items: {
+          where: { payment_order: { status: 'CONFIRMED' } },
+          select: { id: true },
+        },
+      },
+    });
+
+    if (!expense) throw new Error('Gasto no encontrado o no se puede cancelar');
+
+    if (expense.payment_order_items.length > 0) {
+      throw new Error('No se puede cancelar un gasto con pagos confirmados');
+    }
+
+    await prisma.expenses.update({
+      where: { id },
+      data: { status: 'CANCELLED' },
+    });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al cancelar gasto:', error);
+    throw new Error('Error al cancelar gasto');
+  }
+}
+
+/**
+ * Elimina un gasto (solo DRAFT, hard delete)
+ */
+export async function deleteExpense(id: string) {
+  await requirePermission('compras.gastos.delete');
+  const { companyId } = await getActionContext();
+  if (!companyId) throw new Error('No hay empresa activa');
+
+  try {
+    const expense = await prisma.expenses.findFirst({
+      where: { id, company_id: companyId, status: 'DRAFT' },
+      select: { id: true },
+    });
+
+    if (!expense) throw new Error('Gasto no encontrado o no esta en estado borrador');
+
+    await prisma.expenses.delete({ where: { id } });
+
+    revalidatePath(REVALIDATE_PATH);
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    console.error('Error al eliminar gasto:', error);
+    throw new Error('Error al eliminar gasto');
+  }
+}
+
+// ============================================
+// GASTOS PENDIENTES (para Ordenes de Pago)
+// ============================================
+
+/**
+ * Obtiene gastos pendientes de pago (CONFIRMED / PARTIAL_PAID).
+ * Si se pasa supplierId, filtra por proveedor; si no, devuelve todos los de la empresa.
+ */
+export async function getPendingExpenses(supplierId?: string) {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  try {
+    const expenses = await prisma.expenses.findMany({
+      where: {
+        company_id: companyId,
+        status: { in: ['CONFIRMED', 'PARTIAL_PAID'] },
+        ...(supplierId ? { supplier_id: supplierId } : {}),
+      },
+      select: {
+        id: true,
+        full_number: true,
+        description: true,
+        amount: true,
+        date: true,
+        due_date: true,
+        status: true,
+        category: { select: { name: true } },
+        supplier: { select: { business_name: true } },
+        payment_order_items: {
+          where: { payment_order: { status: 'CONFIRMED' } },
+          select: { amount: true },
+        },
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    return expenses.map((expense) => {
+      const paidAmount = expense.payment_order_items.reduce(
+        (sum, item) => sum + Number(item.amount),
+        0,
+      );
+      const total = Number(expense.amount);
+      return {
+        id: expense.id,
+        full_number: expense.full_number,
+        description: expense.description,
+        category_name: expense.category.name,
+        supplier_name: expense.supplier?.business_name || null,
+        date: normalizeDbDate(expense.date),
+        due_date: normalizeDbDateNullable(expense.due_date),
+        total,
+        paid_amount: paidAmount,
+        pending_amount: total - paidAmount,
+        status: expense.status,
+      };
+    });
+  } catch (error) {
+    console.error('Error al obtener gastos pendientes:', error);
+    throw new Error('Error al obtener gastos pendientes');
+  }
+}
+
+// ============================================
+// EXPORT PARA EXCEL
+// ============================================
+
+/**
+ * Obtiene todos los gastos de la empresa para exportar a Excel
+ */
+export async function getAllExpensesForExport() {
+  await requirePermission('compras.gastos.view');
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  const expenses = await prisma.expenses.findMany({
+    where: { company_id: companyId },
+    select: {
+      full_number: true,
+      description: true,
+      amount: true,
+      date: true,
+      due_date: true,
+      status: true,
+      notes: true,
+      category: { select: { name: true } },
+      supplier: { select: { business_name: true } },
+    },
+    orderBy: { number: 'desc' },
+  });
+
+  return expenses.map((e) => ({
+    ...e,
+    amount: Number(e.amount),
+    date: normalizeDbDate(e.date),
+    due_date: normalizeDbDateNullable(e.due_date),
+  }));
+}
+
+// ============================================
+// PROVEEDORES (query local al modulo)
+// ============================================
+
+/**
+ * Obtiene proveedores activos para el select del formulario de gastos
+ */
+export async function getSuppliersForExpenses() {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  return prisma.suppliers.findMany({
+    where: { company_id: companyId },
+    select: {
+      id: true,
+      code: true,
+      business_name: true,
+      tax_id: true,
+    },
+    orderBy: { business_name: 'asc' },
+  });
+}

--- a/src/modules/purchasing/features/expenses/components/_CategoryManagementModal.tsx
+++ b/src/modules/purchasing/features/expenses/components/_CategoryManagementModal.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Settings, Plus, Edit2, Check, X, Power } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/components/ui/dialog';
+import { Button } from '@/shared/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/components/ui/form';
+import { Input } from '@/shared/components/ui/input';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { Badge } from '@/shared/components/ui/badge';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import { Separator } from '@/shared/components/ui/separator';
+import { cn } from '@/shared/lib/utils';
+
+import {
+  getAllExpenseCategories,
+  createExpenseCategory,
+  updateExpenseCategory,
+  toggleExpenseCategory,
+} from '../actions.server';
+import { expenseCategoryFormSchema, type ExpenseCategoryFormInput } from '../validators';
+
+type CategoryItem = Awaited<ReturnType<typeof getAllExpenseCategories>>[number];
+
+interface EditState {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface CategoryManagementModalProps {
+  trigger?: ReactNode;
+  onClose?: () => void;
+}
+
+export function _CategoryManagementModal({ trigger, onClose }: CategoryManagementModalProps) {
+  const [open, setOpen] = useState(false);
+  const [categories, setCategories] = useState<CategoryItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [editState, setEditState] = useState<EditState | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const createForm = useForm<ExpenseCategoryFormInput>({
+    resolver: zodResolver(expenseCategoryFormSchema),
+    defaultValues: { name: '', description: '' },
+  });
+
+  const loadCategories = async () => {
+    setLoading(true);
+    try {
+      const data = await getAllExpenseCategories();
+      setCategories(data);
+    } catch (error) {
+      console.error('Error al cargar categorias:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = async (data: ExpenseCategoryFormInput) => {
+    try {
+      await createExpenseCategory(data);
+      toast.success('Categoria creada correctamente');
+      createForm.reset();
+      await loadCategories();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al crear categoria');
+    }
+  };
+
+  const handleEditSave = async (category: CategoryItem) => {
+    if (!editState) return;
+
+    try {
+      await updateExpenseCategory(category.id, {
+        name: editState.name,
+        description: editState.description || null,
+      });
+      toast.success('Categoria actualizada correctamente');
+      setEditState(null);
+      await loadCategories();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al actualizar categoria');
+    }
+  };
+
+  const handleToggle = async (category: CategoryItem) => {
+    setTogglingId(category.id);
+    try {
+      await toggleExpenseCategory(category.id);
+      toast.success(category.is_active ? 'Categoria desactivada' : 'Categoria activada');
+      await loadCategories();
+    } catch (error) {
+      console.error('Error al toggle categoria:', error);
+      toast.error(error instanceof Error ? error.message : 'Error al cambiar estado');
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (value) {
+      loadCategories();
+    } else {
+      setEditState(null);
+      onClose?.();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button variant="outline" size="sm">
+            <Settings className="mr-2 h-4 w-4" />
+            Gestionar Categorias
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Gestion de Categorias</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Nueva categoria */}
+          <Form {...createForm}>
+            <form onSubmit={createForm.handleSubmit(handleCreate)} className="space-y-3">
+              <h3 className="text-sm font-medium">Nueva Categoria</h3>
+              <FormField
+                control={createForm.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nombre *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nombre de la categoria" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={createForm.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Descripcion (opcional)</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Descripcion de la categoria"
+                        rows={2}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" size="sm" disabled={createForm.formState.isSubmitting}>
+                <Plus className="mr-2 h-4 w-4" />
+                {createForm.formState.isSubmitting ? 'Creando...' : 'Agregar'}
+              </Button>
+            </form>
+          </Form>
+
+          <Separator />
+
+          {/* Lista de categorias */}
+          <div>
+            <h3 className="text-sm font-medium mb-3">Categorias existentes</h3>
+
+            {loading && (
+              <div className="space-y-2">
+                <Skeleton className="h-12 w-full" />
+                <Skeleton className="h-12 w-full" />
+                <Skeleton className="h-12 w-full" />
+              </div>
+            )}
+
+            {!loading && categories.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No hay categorias creadas aun
+              </p>
+            )}
+
+            {!loading && categories.length > 0 && (
+              <div className="space-y-2">
+                {categories.map((category) => (
+                  <div
+                    key={category.id}
+                    className={cn(
+                      'p-3 border rounded-lg',
+                      !category.is_active && 'opacity-60 bg-muted/30',
+                    )}
+                  >
+                    {editState?.id === category.id ? (
+                      <div className="space-y-2">
+                        <Input
+                          value={editState.name}
+                          onChange={(e) =>
+                            setEditState((prev) => (prev ? { ...prev, name: e.target.value } : null))
+                          }
+                          placeholder="Nombre"
+                          className="h-8 text-sm"
+                        />
+                        <Input
+                          value={editState.description}
+                          onChange={(e) =>
+                            setEditState((prev) =>
+                              prev ? { ...prev, description: e.target.value } : null,
+                            )
+                          }
+                          placeholder="Descripcion (opcional)"
+                          className="h-8 text-sm"
+                        />
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="default"
+                            className="h-7 text-xs"
+                            onClick={() => handleEditSave(category)}
+                          >
+                            <Check className="mr-1 h-3 w-3" />
+                            Guardar
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 text-xs"
+                            onClick={() => setEditState(null)}
+                          >
+                            <X className="mr-1 h-3 w-3" />
+                            Cancelar
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium">{category.name}</p>
+                            {!category.is_active && (
+                              <Badge variant="secondary" className="text-xs">
+                                Inactiva
+                              </Badge>
+                            )}
+                          </div>
+                          {category.description && (
+                            <p className="text-xs text-muted-foreground mt-0.5">
+                              {category.description}
+                            </p>
+                          )}
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {category._count.expenses} gasto{category._count.expenses !== 1 ? 's' : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() =>
+                              setEditState({
+                                id: category.id,
+                                name: category.name,
+                                description: category.description ?? '',
+                              })
+                            }
+                            title="Editar"
+                          >
+                            <Edit2 className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            disabled={togglingId === category.id}
+                            onClick={() => handleToggle(category)}
+                            title={category.is_active ? 'Desactivar' : 'Activar'}
+                          >
+                            <Power
+                              className={cn(
+                                'h-3.5 w-3.5',
+                                category.is_active ? 'text-green-600' : 'text-muted-foreground',
+                              )}
+                            />
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/purchasing/features/expenses/index.ts
+++ b/src/modules/purchasing/features/expenses/index.ts
@@ -1,0 +1,1 @@
+export { ExpensesList } from './list/ExpensesList';

--- a/src/modules/purchasing/features/expenses/list/ExpensesList.tsx
+++ b/src/modules/purchasing/features/expenses/list/ExpensesList.tsx
@@ -1,0 +1,34 @@
+import type { DataTableSearchParams } from '@/shared/components/common/DataTable';
+import { getExpensesPaginated, getExpenseFacetCounts, getExpenseCategories } from '../actions.server';
+import { _ExpensesDataTable } from './components/_ExpensesDataTable';
+import { NoAccessView } from '@/shared/components/common/NoAccessView';
+import { PermissionDeniedError } from '@/shared/lib/permissions';
+
+interface Props {
+  searchParams?: DataTableSearchParams;
+}
+
+export async function ExpensesList({ searchParams = {} }: Props) {
+  try {
+    const [{ data, total }, facetCounts, categories] = await Promise.all([
+      getExpensesPaginated(searchParams),
+      getExpenseFacetCounts(),
+      getExpenseCategories(),
+    ]);
+
+    return (
+      <_ExpensesDataTable
+        data={data as any}
+        totalRows={total}
+        searchParams={searchParams}
+        facetCounts={facetCounts}
+        categories={categories}
+      />
+    );
+  } catch (error) {
+    if (error instanceof PermissionDeniedError) {
+      return <NoAccessView module="Gastos" permission={error.permission} />;
+    }
+    throw error;
+  }
+}

--- a/src/modules/purchasing/features/expenses/list/columns.tsx
+++ b/src/modules/purchasing/features/expenses/list/columns.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { MoreHorizontal, Eye, Edit, CheckCircle, XCircle, Trash2 } from 'lucide-react';
+import { format, isBefore, startOfDay } from 'date-fns';
+
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/shared/components/ui/dropdown-menu';
+import { DataTableColumnHeader } from '@/shared/components/common/DataTable';
+import { EXPENSE_STATUS_LABELS } from '../validators';
+
+export type ExpenseListItem = {
+  id: string;
+  number: number;
+  full_number: string;
+  description: string;
+  amount: number;
+  date: Date;
+  due_date: Date | null;
+  status: string;
+  created_at: Date;
+  category: { id: string; name: string };
+  supplier: { id: string; business_name: string } | null;
+  _count: { expense_attachments: number; payment_order_items: number };
+} & Record<string, unknown>;
+
+type BadgeVariant = 'secondary' | 'default' | 'outline' | 'destructive';
+
+const STATUS_BADGE_VARIANTS: Record<string, BadgeVariant> = {
+  DRAFT: 'secondary',
+  CONFIRMED: 'default',
+  PARTIAL_PAID: 'outline',
+  PAID: 'default',
+  CANCELLED: 'destructive',
+};
+
+interface ColumnsProps {
+  onViewDetail: (expense: ExpenseListItem) => void;
+  onEdit?: (expense: ExpenseListItem) => void;
+  onConfirm?: (expense: ExpenseListItem) => void;
+  onCancel?: (expense: ExpenseListItem) => void;
+  onDelete?: (expense: ExpenseListItem) => void;
+}
+
+export function getExpenseColumns({
+  onViewDetail,
+  onEdit,
+  onConfirm,
+  onCancel,
+  onDelete,
+}: ColumnsProps): ColumnDef<ExpenseListItem>[] {
+  return [
+    {
+      accessorKey: 'full_number',
+      meta: { title: 'Numero' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Numero" />,
+      cell: ({ row }) => (
+        <button
+          type="button"
+          className="font-mono font-medium text-primary hover:underline cursor-pointer"
+          onClick={() => onViewDetail(row.original)}
+        >
+          {row.original.full_number}
+        </button>
+      ),
+    },
+    {
+      accessorKey: 'description',
+      meta: { title: 'Descripcion' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Descripcion" />,
+      cell: ({ row }) => (
+        <span className="max-w-[200px] truncate block" title={row.original.description}>
+          {row.original.description}
+        </span>
+      ),
+    },
+    {
+      id: 'category_id',
+      accessorFn: (row) => row.category.name,
+      meta: { title: 'Categoria' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Categoria" />,
+      cell: ({ row }) => row.original.category.name,
+    },
+    {
+      id: 'supplier',
+      accessorFn: (row) => row.supplier?.business_name ?? '',
+      meta: { title: 'Proveedor' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Proveedor" />,
+      cell: ({ row }) => {
+        const supplier = row.original.supplier;
+        if (!supplier) return <span className="text-muted-foreground">-</span>;
+        return supplier.business_name;
+      },
+    },
+    {
+      accessorKey: 'date',
+      meta: { title: 'Fecha' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Fecha" />,
+      cell: ({ row }) => format(new Date(row.original.date), 'dd/MM/yyyy'),
+    },
+    {
+      accessorKey: 'due_date',
+      meta: { title: 'Vencimiento' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Vencimiento" />,
+      cell: ({ row }) => {
+        const { due_date, status } = row.original;
+        if (!due_date) return <span className="text-muted-foreground">-</span>;
+
+        const isOverdue =
+          status !== 'PAID' &&
+          status !== 'CANCELLED' &&
+          isBefore(new Date(due_date), startOfDay(new Date()));
+
+        return (
+          <span className={isOverdue ? 'text-red-600 font-medium' : undefined}>
+            {format(new Date(due_date), 'dd/MM/yyyy')}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: 'amount',
+      meta: { title: 'Monto' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Monto" />,
+      cell: ({ row }) => (
+        <span className="font-mono font-medium text-right block">
+          ${row.original.amount.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      meta: { title: 'Estado' },
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Estado" />,
+      cell: ({ row }) => {
+        const status = row.original.status;
+        const isPaid = status === 'PAID';
+
+        return (
+          <Badge
+            variant={STATUS_BADGE_VARIANTS[status] ?? 'default'}
+            className={isPaid ? 'bg-green-600 hover:bg-green-700 text-white' : undefined}
+          >
+            {EXPENSE_STATUS_LABELS[status] ?? status}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => {
+        const expense = row.original;
+        const isDraft = expense.status === 'DRAFT';
+        const canCancel = expense.status === 'DRAFT' || expense.status === 'CONFIRMED';
+
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0">
+                <span className="sr-only">Abrir menu</span>
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onViewDetail(expense)}>
+                <Eye className="mr-2 h-4 w-4" />
+                Ver detalle
+              </DropdownMenuItem>
+
+              {isDraft && onEdit && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => onEdit(expense)}>
+                    <Edit className="mr-2 h-4 w-4" />
+                    Editar
+                  </DropdownMenuItem>
+                </>
+              )}
+
+              {isDraft && onConfirm && (
+                <DropdownMenuItem onClick={() => onConfirm(expense)}>
+                  <CheckCircle className="mr-2 h-4 w-4" />
+                  Confirmar
+                </DropdownMenuItem>
+              )}
+
+              {canCancel && onCancel && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => onCancel(expense)} className="text-destructive">
+                    <XCircle className="mr-2 h-4 w-4" />
+                    Cancelar
+                  </DropdownMenuItem>
+                </>
+              )}
+
+              {isDraft && onDelete && (
+                <DropdownMenuItem onClick={() => onDelete(expense)} className="text-destructive">
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Eliminar
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      },
+    },
+  ];
+}

--- a/src/modules/purchasing/features/expenses/list/components/_CreateExpenseModal.tsx
+++ b/src/modules/purchasing/features/expenses/list/components/_CreateExpenseModal.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Plus, Settings } from 'lucide-react';
+import { format } from 'date-fns';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/components/ui/dialog';
+import { Button } from '@/shared/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/components/ui/form';
+import { Input } from '@/shared/components/ui/input';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { SearchableSelect, type SearchableSelectOption } from '@/shared/components/ui/searchable-select';
+
+import { expenseFormSchema, type ExpenseFormInput } from '../../validators';
+import {
+  createExpense,
+  updateExpense,
+  getExpenseById,
+  getExpenseCategories,
+  getSuppliersForExpenses,
+} from '../../actions.server';
+import { _CategoryManagementModal } from '../../components/_CategoryManagementModal';
+
+interface CreateExpenseModalProps {
+  expenseId?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+export function _CreateExpenseModal({
+  expenseId,
+  open: controlledOpen,
+  onOpenChange,
+  onSuccess,
+}: CreateExpenseModalProps) {
+  const isEditMode = Boolean(expenseId);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [categories, setCategories] = useState<SearchableSelectOption[]>([]);
+  const [suppliers, setSuppliers] = useState<SearchableSelectOption[]>([]);
+
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setOpen = (value: boolean) => {
+    if (onOpenChange) {
+      onOpenChange(value);
+    } else {
+      setInternalOpen(value);
+    }
+  };
+
+  const form = useForm<ExpenseFormInput>({
+    resolver: zodResolver(expenseFormSchema),
+    defaultValues: {
+      description: '',
+      amount: '',
+      date: new Date(),
+      due_date: null,
+      category_id: '',
+      supplier_id: '',
+      notes: '',
+    },
+  });
+
+  // Load catalogs when modal opens
+  useEffect(() => {
+    if (!open) return;
+
+    getExpenseCategories()
+      .then((cats) =>
+        setCategories(cats.map((c) => ({ value: c.id, label: c.name }))),
+      )
+      .catch(console.error);
+
+    getSuppliersForExpenses()
+      .then((sups) =>
+        setSuppliers(
+          sups.map((s) => ({
+            value: s.id,
+            label: `${s.business_name} (${s.tax_id})`,
+          })),
+        ),
+      )
+      .catch(console.error);
+  }, [open]);
+
+  // Load expense data for editing
+  useEffect(() => {
+    if (isEditMode && expenseId && open) {
+      getExpenseById(expenseId).then((data) => {
+        form.reset({
+          description: data.description,
+          amount: data.amount.toString(),
+          date: new Date(data.date),
+          due_date: data.due_date ? new Date(data.due_date) : null,
+          category_id: data.category.id,
+          supplier_id: data.supplier?.id ?? '',
+          notes: data.notes ?? '',
+        });
+      });
+    }
+  }, [isEditMode, expenseId, open, form]);
+
+  const reloadCategories = () => {
+    getExpenseCategories()
+      .then((cats) =>
+        setCategories(cats.map((c) => ({ value: c.id, label: c.name }))),
+      )
+      .catch(console.error);
+  };
+
+  const onSubmit = async (data: ExpenseFormInput) => {
+    try {
+      if (isEditMode && expenseId) {
+        await updateExpense(expenseId, data);
+        toast.success('Gasto actualizado correctamente');
+      } else {
+        await createExpense(data);
+        toast.success('Gasto creado correctamente');
+      }
+
+      setOpen(false);
+      form.reset();
+      onSuccess?.();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al guardar el gasto');
+    }
+  };
+
+  const content = (
+    <DialogContent className="max-w-2xl">
+      <DialogHeader>
+        <DialogTitle>{isEditMode ? 'Editar Gasto' : 'Nuevo Gasto'}</DialogTitle>
+      </DialogHeader>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          {/* Descripcion */}
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Descripcion *</FormLabel>
+                <FormControl>
+                  <Input placeholder="Descripcion del gasto" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Monto y Fecha */}
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Monto *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      step="0.001"
+                      min="0"
+                      placeholder="0.00"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Fecha *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      value={field.value ? format(field.value, 'yyyy-MM-dd') : ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        field.onChange(val ? new Date(val + 'T12:00:00') : null);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Fecha de Vencimiento */}
+          <FormField
+            control={form.control}
+            name="due_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Fecha de Vencimiento (opcional)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="date"
+                    value={field.value ? format(field.value, 'yyyy-MM-dd') : ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      field.onChange(val ? new Date(val + 'T12:00:00') : null);
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Categoria */}
+          <FormField
+            control={form.control}
+            name="category_id"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Categoria *</FormLabel>
+                  <_CategoryManagementModal
+                    trigger={
+                      <Button type="button" variant="ghost" size="sm" className="h-6 gap-1 text-xs">
+                        <Settings className="h-3 w-3" />
+                        Gestionar
+                      </Button>
+                    }
+                    onClose={reloadCategories}
+                  />
+                </div>
+                <FormControl>
+                  <SearchableSelect
+                    options={categories}
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    placeholder="Seleccionar categoria"
+                    searchPlaceholder="Buscar categoria..."
+                    emptyMessage="No hay categorias disponibles"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Proveedor */}
+          <FormField
+            control={form.control}
+            name="supplier_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Proveedor (opcional)</FormLabel>
+                <FormControl>
+                  <SearchableSelect
+                    options={[{ value: '', label: 'Sin proveedor' }, ...suppliers]}
+                    value={field.value ?? ''}
+                    onValueChange={(val) => field.onChange(val || '')}
+                    placeholder="Seleccionar proveedor (opcional)"
+                    searchPlaceholder="Buscar proveedor..."
+                    emptyMessage="Sin resultados"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Notas */}
+          <FormField
+            control={form.control}
+            name="notes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Notas (opcional)</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Observaciones adicionales"
+                    {...field}
+                    value={field.value ?? ''}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting
+                ? isEditMode
+                  ? 'Guardando...'
+                  : 'Creando...'
+                : isEditMode
+                  ? 'Guardar Cambios'
+                  : 'Crear Gasto'}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </DialogContent>
+  );
+
+  if (isEditMode) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        {content}
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Nuevo Gasto
+        </Button>
+      </DialogTrigger>
+      {content}
+    </Dialog>
+  );
+}

--- a/src/modules/purchasing/features/expenses/list/components/_ExpenseDetailModal.tsx
+++ b/src/modules/purchasing/features/expenses/list/components/_ExpenseDetailModal.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { format, isBefore, startOfDay } from 'date-fns';
+import { CheckCircle, XCircle } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { Badge } from '@/shared/components/ui/badge';
+import { Button } from '@/shared/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui/card';
+import { Skeleton } from '@/shared/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+import { Separator } from '@/shared/components/ui/separator';
+import { cn } from '@/shared/lib/utils';
+
+import { getExpenseById, confirmExpense, cancelExpense } from '../../actions.server';
+import { EXPENSE_STATUS_LABELS } from '../../validators';
+
+type ExpenseDetail = Awaited<ReturnType<typeof getExpenseById>>;
+
+type BadgeVariant = 'secondary' | 'default' | 'outline' | 'destructive';
+
+const STATUS_BADGE_VARIANTS: Record<string, BadgeVariant> = {
+  DRAFT: 'secondary',
+  CONFIRMED: 'default',
+  PARTIAL_PAID: 'outline',
+  PAID: 'default',
+  CANCELLED: 'destructive',
+};
+
+interface ExpenseDetailModalProps {
+  expenseId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+export function _ExpenseDetailModal({
+  expenseId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: ExpenseDetailModalProps) {
+  const router = useRouter();
+  const [expense, setExpense] = useState<ExpenseDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const loadExpense = useCallback(async () => {
+    if (!expenseId) return;
+
+    setLoading(true);
+    try {
+      const data = await getExpenseById(expenseId);
+      setExpense(data);
+    } catch (error) {
+      console.error('Error al cargar gasto:', error);
+      toast.error('Error al cargar el detalle del gasto');
+    } finally {
+      setLoading(false);
+    }
+  }, [expenseId]);
+
+  useEffect(() => {
+    if (open && expenseId) {
+      loadExpense();
+    } else if (!open) {
+      setExpense(null);
+    }
+  }, [open, expenseId, loadExpense]);
+
+  const handleConfirm = async () => {
+    if (!expense) return;
+
+    setIsProcessing(true);
+    try {
+      await confirmExpense(expense.id);
+      toast.success('Gasto confirmado correctamente');
+      setConfirmDialogOpen(false);
+      router.refresh();
+      onSuccess?.();
+      await loadExpense();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al confirmar gasto');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!expense) return;
+
+    setIsProcessing(true);
+    try {
+      await cancelExpense(expense.id);
+      toast.success('Gasto cancelado correctamente');
+      setCancelDialogOpen(false);
+      router.refresh();
+      onSuccess?.();
+      await loadExpense();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al cancelar gasto');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const isDraft = expense?.status === 'DRAFT';
+  const isConfirmed = expense?.status === 'CONFIRMED';
+  const canCancel = isDraft || isConfirmed;
+  const hasPayments = (expense?.payment_order_items?.length ?? 0) > 0;
+  const isPaid = expense?.status === 'PAID';
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Detalle de Gasto</DialogTitle>
+          </DialogHeader>
+
+          {loading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-32 w-full" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          ) : expense ? (
+            <div className="space-y-4">
+              {/* Informacion General */}
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex items-start justify-between">
+                    <CardTitle className="text-base">Informacion General</CardTitle>
+                    <Badge
+                      variant={STATUS_BADGE_VARIANTS[expense.status] ?? 'default'}
+                      className={cn(isPaid && 'bg-green-600 hover:bg-green-700 text-white')}
+                    >
+                      {EXPENSE_STATUS_LABELS[expense.status] ?? expense.status}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <p className="text-sm text-muted-foreground">Numero</p>
+                      <p className="font-medium font-mono">{expense.full_number}</p>
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">Categoria</p>
+                      <p className="font-medium">{expense.category.name}</p>
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">Fecha</p>
+                      <p className="font-medium">{format(new Date(expense.date), 'dd/MM/yyyy')}</p>
+                    </div>
+                    {expense.due_date && (
+                      <div>
+                        <p className="text-sm text-muted-foreground">Vencimiento</p>
+                        <p
+                          className={cn(
+                            'font-medium',
+                            !isPaid &&
+                              expense.status !== 'CANCELLED' &&
+                              isBefore(new Date(expense.due_date), startOfDay(new Date())) &&
+                              'text-red-600',
+                          )}
+                        >
+                          {format(new Date(expense.due_date), 'dd/MM/yyyy')}
+                        </p>
+                      </div>
+                    )}
+                    <div className="col-span-2">
+                      <p className="text-sm text-muted-foreground">Descripcion</p>
+                      <p className="font-medium">{expense.description}</p>
+                    </div>
+                    {expense.supplier && (
+                      <div className="col-span-2">
+                        <p className="text-sm text-muted-foreground">Proveedor</p>
+                        <p className="font-medium">{expense.supplier.business_name}</p>
+                        {expense.supplier.tax_id && (
+                          <p className="text-xs text-muted-foreground">
+                            CUIT: {expense.supplier.tax_id}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                    {expense.notes && (
+                      <div className="col-span-2">
+                        <p className="text-sm text-muted-foreground">Notas</p>
+                        <p className="text-sm">{expense.notes}</p>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Resumen de Pagos */}
+              <Card>
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base">Resumen Financiero</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Monto Total</span>
+                      <span className="font-medium font-mono">
+                        $
+                        {expense.amount.toLocaleString('es-AR', {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </span>
+                    </div>
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Pagado</span>
+                      <span className="font-medium font-mono text-green-600">
+                        -$
+                        {expense.paidAmount.toLocaleString('es-AR', {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </span>
+                    </div>
+                    <Separator />
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm font-medium">Pendiente</span>
+                      <span
+                        className={cn(
+                          'font-bold text-lg font-mono',
+                          expense.pendingAmount > 0 ? 'text-orange-600' : 'text-green-600',
+                        )}
+                      >
+                        $
+                        {expense.pendingAmount.toLocaleString('es-AR', {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Ordenes de Pago Vinculadas */}
+              {expense.payment_order_items.length > 0 && (
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base">Ordenes de Pago</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-2">
+                      {expense.payment_order_items.map((item) => (
+                        <div
+                          key={item.id}
+                          className="flex justify-between items-center p-3 border rounded-lg"
+                        >
+                          <div>
+                            <p className="font-medium">{item.payment_order.full_number}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {format(new Date(item.payment_order.date), 'dd/MM/yyyy')}{' '}
+                              &middot; {item.payment_order.status}
+                            </p>
+                          </div>
+                          <div className="text-right">
+                            <p className="font-medium font-mono">
+                              $
+                              {item.amount.toLocaleString('es-AR', {
+                                minimumFractionDigits: 2,
+                              })}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Adjuntos */}
+              {expense.expense_attachments.length > 0 && (
+                <Card>
+                  <CardHeader className="pb-3">
+                    <CardTitle className="text-base">Adjuntos</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-1">
+                      {expense.expense_attachments.map((att) => (
+                        <div
+                          key={att.id}
+                          className="flex items-center justify-between py-1 text-sm"
+                        >
+                          <span className="truncate">{att.file_name}</span>
+                          {att.file_size && (
+                            <span className="text-xs text-muted-foreground ml-2">
+                              {(att.file_size / 1024).toFixed(0)} KB
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Acciones */}
+              <div className="flex justify-end gap-2 pt-2">
+                {isDraft && (
+                  <Button
+                    variant="default"
+                    onClick={() => setConfirmDialogOpen(true)}
+                    disabled={isProcessing}
+                  >
+                    <CheckCircle className="mr-2 h-4 w-4" />
+                    Confirmar
+                  </Button>
+                )}
+                {canCancel && !hasPayments && (
+                  <Button
+                    variant="destructive"
+                    onClick={() => setCancelDialogOpen(true)}
+                    disabled={isProcessing}
+                  >
+                    <XCircle className="mr-2 h-4 w-4" />
+                    Cancelar Gasto
+                  </Button>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirm Dialog */}
+      <AlertDialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmar gasto</AlertDialogTitle>
+            <AlertDialogDescription>
+              Al confirmar el gasto {expense?.full_number}, quedara registrado como confirmado y
+              podra ser incluido en una orden de pago. Esta accion no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isProcessing}>Volver</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm} disabled={isProcessing}>
+              {isProcessing ? 'Confirmando...' : 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Cancel Dialog */}
+      <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancelar gasto</AlertDialogTitle>
+            <AlertDialogDescription>
+              Estas seguro de que deseas cancelar el gasto {expense?.full_number}? Esta accion no
+              se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isProcessing}>Volver</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleCancel}
+              disabled={isProcessing}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isProcessing ? 'Cancelando...' : 'Cancelar Gasto'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/modules/purchasing/features/expenses/list/components/_ExpensesDataTable.tsx
+++ b/src/modules/purchasing/features/expenses/list/components/_ExpensesDataTable.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import {
+  DataTable,
+  type DataTableSearchParams,
+  type DataTableFacetedFilterConfig,
+} from '@/shared/components/common/DataTable';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+
+import { confirmExpense, cancelExpense, deleteExpense, getAllExpensesForExport } from '../../actions.server';
+import { getExpenseColumns, type ExpenseListItem } from '../columns';
+import { EXPENSE_STATUS_LABELS } from '../../validators';
+import { _CreateExpenseModal } from './_CreateExpenseModal';
+import { _ExpenseDetailModal } from './_ExpenseDetailModal';
+
+interface FacetCounts {
+  status?: { value: string; count: number }[];
+  category_id?: { value: string; count: number }[];
+}
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  data: ExpenseListItem[];
+  totalRows: number;
+  searchParams: DataTableSearchParams;
+  facetCounts?: FacetCounts;
+  categories?: CategoryOption[];
+}
+
+export function _ExpensesDataTable({
+  data,
+  totalRows,
+  searchParams,
+  facetCounts,
+  categories = [],
+}: Props) {
+  const router = useRouter();
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [detailModalOpen, setDetailModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [selectedExpense, setSelectedExpense] = useState<ExpenseListItem | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleConfirm = async () => {
+    if (!selectedExpense) return;
+
+    setIsProcessing(true);
+    try {
+      await confirmExpense(selectedExpense.id);
+      toast.success('Gasto confirmado correctamente');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al confirmar gasto');
+    } finally {
+      setIsProcessing(false);
+      setConfirmDialogOpen(false);
+      setSelectedExpense(null);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!selectedExpense) return;
+
+    setIsProcessing(true);
+    try {
+      await cancelExpense(selectedExpense.id);
+      toast.success('Gasto cancelado correctamente');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al cancelar gasto');
+    } finally {
+      setIsProcessing(false);
+      setCancelDialogOpen(false);
+      setSelectedExpense(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selectedExpense) return;
+
+    setIsProcessing(true);
+    try {
+      await deleteExpense(selectedExpense.id);
+      toast.success('Gasto eliminado correctamente');
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al eliminar gasto');
+    } finally {
+      setIsProcessing(false);
+      setDeleteDialogOpen(false);
+      setSelectedExpense(null);
+    }
+  };
+
+  const facetedFilters: DataTableFacetedFilterConfig[] = useMemo(
+    () => [
+      {
+        columnId: 'full_number',
+        title: 'Numero',
+        type: 'text' as const,
+        placeholder: 'Buscar por numero...',
+      },
+      {
+        columnId: 'description',
+        title: 'Descripcion',
+        type: 'text' as const,
+        placeholder: 'Buscar por descripcion...',
+      },
+      {
+        columnId: 'supplier',
+        title: 'Proveedor',
+        type: 'text' as const,
+        placeholder: 'Buscar por proveedor...',
+      },
+      {
+        columnId: 'status',
+        title: 'Estado',
+        options: Object.entries(EXPENSE_STATUS_LABELS).map(([value, label]) => ({
+          label,
+          value,
+        })),
+        externalCounts: facetCounts?.status
+          ? new Map(facetCounts.status.map((f) => [f.value, f.count]))
+          : undefined,
+      },
+      {
+        columnId: 'category_id',
+        title: 'Categoria',
+        options: categories.map((c) => ({
+          value: c.id,
+          label: c.name,
+        })),
+        externalCounts: facetCounts?.category_id
+          ? new Map(facetCounts.category_id.map((f) => [f.value, f.count]))
+          : undefined,
+      },
+      {
+        columnId: 'date',
+        title: 'Fecha',
+        type: 'dateRange' as const,
+      },
+      {
+        columnId: 'due_date',
+        title: 'Vencimiento',
+        type: 'dateRange' as const,
+      },
+    ],
+    [facetCounts, categories],
+  );
+
+  const columns = useMemo(
+    () =>
+      getExpenseColumns({
+        onViewDetail: (expense) => {
+          setSelectedExpense(expense);
+          setDetailModalOpen(true);
+        },
+        onEdit: (expense) => {
+          setSelectedExpense(expense);
+          setEditModalOpen(true);
+        },
+        onConfirm: (expense) => {
+          setSelectedExpense(expense);
+          setConfirmDialogOpen(true);
+        },
+        onCancel: (expense) => {
+          setSelectedExpense(expense);
+          setCancelDialogOpen(true);
+        },
+        onDelete: (expense) => {
+          setSelectedExpense(expense);
+          setDeleteDialogOpen(true);
+        },
+      }),
+    [],
+  );
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={data}
+        totalRows={totalRows}
+        searchParams={searchParams}
+        searchPlaceholder="Buscar por numero, descripcion, proveedor o categoria..."
+        facetedFilters={facetedFilters}
+        tableId="expenses-list"
+        showFilterToggle
+        toolbarActions={<_CreateExpenseModal onSuccess={() => router.refresh()} />}
+        exportConfig={{
+          fetchAllData: () => getAllExpensesForExport() as any,
+          options: {
+            filename: 'gastos',
+            sheetName: 'Gastos',
+            title: 'Listado de Gastos',
+            includeDate: true,
+          },
+        }}
+      />
+
+      {/* Dialogo de Confirmacion */}
+      <AlertDialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmar gasto</AlertDialogTitle>
+            <AlertDialogDescription>
+              Al confirmar el gasto {selectedExpense?.full_number}, quedara registrado como
+              confirmado y podra ser incluido en una orden de pago. Esta accion no se puede
+              deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isProcessing}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm} disabled={isProcessing}>
+              {isProcessing ? 'Confirmando...' : 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Dialogo de Cancelacion */}
+      <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancelar gasto</AlertDialogTitle>
+            <AlertDialogDescription>
+              Estas seguro de que deseas cancelar el gasto {selectedExpense?.full_number}? Solo se
+              pueden cancelar gastos sin pagos confirmados. Esta accion no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isProcessing}>Volver</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleCancel}
+              disabled={isProcessing}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isProcessing ? 'Cancelando...' : 'Cancelar Gasto'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Dialogo de Eliminacion */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar gasto</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta accion eliminara permanentemente el gasto {selectedExpense?.full_number} y todos
+              sus registros asociados. Esta accion no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isProcessing}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isProcessing}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isProcessing ? 'Eliminando...' : 'Eliminar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Modal de Detalle */}
+      <_ExpenseDetailModal
+        expenseId={selectedExpense?.id ?? null}
+        open={detailModalOpen}
+        onOpenChange={setDetailModalOpen}
+        onSuccess={() => router.refresh()}
+      />
+
+      {/* Modal de Edicion */}
+      {editModalOpen && selectedExpense && (
+        <_CreateExpenseModal
+          expenseId={selectedExpense.id}
+          open={editModalOpen}
+          onOpenChange={setEditModalOpen}
+          onSuccess={() => {
+            setEditModalOpen(false);
+            router.refresh();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/modules/purchasing/features/expenses/validators.ts
+++ b/src/modules/purchasing/features/expenses/validators.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+// ============================================
+// CONSTANTES
+// ============================================
+
+export const EXPENSE_STATUSES = ['DRAFT', 'CONFIRMED', 'PARTIAL_PAID', 'PAID', 'CANCELLED'] as const;
+
+export const EXPENSE_STATUS_LABELS: Record<string, string> = {
+  DRAFT: 'Borrador',
+  CONFIRMED: 'Confirmado',
+  PARTIAL_PAID: 'Parcialmente pagado',
+  PAID: 'Pagado',
+  CANCELLED: 'Anulado',
+};
+
+// ============================================
+// SCHEMAS ZOD
+// ============================================
+
+export const expenseFormSchema = z.object({
+  description: z.string().min(1, 'La descripcion es requerida'),
+  amount: z.string().regex(/^\d+(\.\d{1,3})?$/, 'Monto invalido (hasta 3 decimales)'),
+  date: z.date({ message: 'La fecha es requerida' }),
+  due_date: z.date().optional().nullable(),
+  category_id: z.string().uuid('Seleccione una categoria'),
+  supplier_id: z.string().uuid().optional().nullable().or(z.literal('')),
+  notes: z.string().optional().nullable(),
+});
+
+export type ExpenseFormInput = z.infer<typeof expenseFormSchema>;
+
+export const expenseCategoryFormSchema = z.object({
+  name: z.string().min(1, 'El nombre es requerido'),
+  description: z.string().optional().nullable(),
+});
+
+export type ExpenseCategoryFormInput = z.infer<typeof expenseCategoryFormSchema>;

--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -146,6 +146,7 @@ export async function getPaymentOrderById(id: string) {
       items: {
         include: {
           invoice: { select: { id: true, full_number: true, issue_date: true, total: true } },
+          expense: { select: { id: true, full_number: true, date: true, amount: true } },
         },
       },
       payments: {
@@ -188,6 +189,7 @@ export async function getPaymentOrderById(id: string) {
       ...i,
       amount: Number(i.amount),
       invoice: i.invoice ? { ...i.invoice, total: Number(i.invoice.total) } : null,
+      expense: i.expense ? { ...i.expense, amount: Number(i.expense.amount) } : null,
     })),
     payments: order.payments.map((p) => ({ ...p, amount: Number(p.amount) })),
     retentions: order.retentions.map((r) => ({
@@ -281,6 +283,71 @@ export async function getPendingPurchaseInvoices(supplierId: string) {
     .filter((inv) => inv.remaining > 0);
 }
 
+export async function getPendingExpenses(supplierId?: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  const where: Record<string, unknown> = {
+    company_id: companyId,
+    status: { in: ['CONFIRMED', 'PARTIAL_PAID'] },
+  };
+  if (supplierId) {
+    where.supplier_id = supplierId;
+  }
+
+  const expenses = await prisma.expenses.findMany({
+    where: where as any,
+    select: {
+      id: true,
+      full_number: true,
+      description: true,
+      date: true,
+      due_date: true,
+      amount: true,
+      category: { select: { id: true, name: true } },
+      supplier: { select: { id: true, business_name: true } },
+      payment_order_items: { select: { amount: true } },
+    },
+    orderBy: { date: 'asc' },
+  });
+
+  return expenses
+    .map((exp) => {
+      const alreadyPaid = exp.payment_order_items.reduce(
+        (acc, item) => acc + Number(item.amount),
+        0
+      );
+      const total = Number(exp.amount);
+      const remaining = Math.round((total - alreadyPaid) * 100) / 100;
+      return {
+        id: exp.id,
+        full_number: exp.full_number,
+        description: exp.description,
+        date: exp.date,
+        due_date: exp.due_date,
+        total,
+        already_paid: Math.round(alreadyPaid * 100) / 100,
+        remaining,
+        category_id: exp.category?.id ?? '',
+        category_name: exp.category?.name ?? '',
+        supplier_id: exp.supplier?.id ?? null,
+        supplier_name: exp.supplier?.business_name ?? '',
+      };
+    })
+    .filter((exp) => exp.remaining > 0);
+}
+
+export async function getExpenseCategoriesForOrder() {
+  const { companyId } = await getActionContext();
+  if (!companyId) return [];
+
+  return prisma.expense_categories.findMany({
+    where: { company_id: companyId, is_active: true },
+    select: { id: true, name: true },
+    orderBy: { name: 'asc' },
+  });
+}
+
 export async function createPaymentOrder(data: PaymentOrderFormData) {
   const { companyId } = await getActionContext();
   if (!companyId) return { data: null, error: 'No company selected' };
@@ -372,6 +439,7 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
         items: {
           create: parsed.data.items.map((i) => ({
             invoice_id: i.invoice_id || null,
+            expense_id: i.expense_id || null,
             amount: parseFloat(i.amount),
           })),
         },
@@ -503,6 +571,7 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
           items: {
             create: parsed.data.items.map((i) => ({
               invoice_id: i.invoice_id || null,
+              expense_id: i.expense_id || null,
               amount: parseFloat(i.amount),
             })),
           },
@@ -725,7 +794,7 @@ export async function markPaymentOrderAsPaid(id: string): Promise<{
     await requirePermission('tesoreria.pay');
     const order = await prisma.payment_orders.findFirst({
       where: { id, company_id: companyId },
-      select: { id: true, status: true, items: { select: { invoice_id: true } } },
+      select: { id: true, status: true, items: { select: { invoice_id: true, expense_id: true } } },
     });
     if (!order) return { ok: false, error: 'Orden no encontrada' };
     if (order.status !== 'CONFIRMED') {
@@ -737,6 +806,9 @@ export async function markPaymentOrderAsPaid(id: string): Promise<{
 
     const invoiceIds = Array.from(
       new Set(order.items.map((i) => i.invoice_id).filter((v): v is string => !!v))
+    );
+    const expenseIds = Array.from(
+      new Set(order.items.map((i) => i.expense_id).filter((v): v is string => !!v))
     );
 
     await prisma.$transaction(async (tx) => {
@@ -778,6 +850,37 @@ export async function markPaymentOrderAsPaid(id: string): Promise<{
           });
         }
       }
+
+      // Actualizar status de gastos vinculados
+      for (const expenseId of expenseIds) {
+        const expense = await tx.expenses.findUnique({
+          where: { id: expenseId },
+          select: { id: true, amount: true, status: true },
+        });
+        if (!expense) continue;
+        if (expense.status === 'CANCELLED') continue;
+
+        const aggregate = await tx.payment_order_items.aggregate({
+          where: {
+            expense_id: expenseId,
+            payment_order: { status: 'PAID' },
+          },
+          _sum: { amount: true },
+        });
+        const paidSum = Number(aggregate._sum.amount ?? 0);
+        const total = Number(expense.amount);
+
+        let nextStatus: 'PAID' | 'PARTIAL_PAID' | null = null;
+        if (paidSum >= total - 0.005) nextStatus = 'PAID';
+        else if (paidSum > 0) nextStatus = 'PARTIAL_PAID';
+
+        if (nextStatus && expense.status !== nextStatus) {
+          await tx.expenses.update({
+            where: { id: expenseId },
+            data: { status: nextStatus },
+          });
+        }
+      }
     });
 
     // Mail al proveedor (fuera de la transacción)
@@ -796,6 +899,9 @@ export async function markPaymentOrderAsPaid(id: string): Promise<{
     revalidatePath(`/dashboard/treasury/payment-orders/${id}`);
     for (const invId of invoiceIds) {
       revalidatePath(`/dashboard/purchasing/invoices/${invId}`);
+    }
+    for (const expId of expenseIds) {
+      revalidatePath(`/dashboard/purchasing/expenses/${expId}`);
     }
 
     return { ok: true, emailStatus, errorMessage };

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
@@ -38,6 +38,8 @@ import {
   createPaymentOrder,
   updatePaymentOrder,
   getPendingPurchaseInvoices,
+  getPendingExpenses,
+  getExpenseCategoriesForOrder,
   getSupplierPaymentMethodsForPaymentOrder,
 } from '../actions.server';
 import { PAYMENT_METHOD_LABELS } from '../../../shared/validators';
@@ -75,10 +77,28 @@ interface InvoiceOption {
   remaining: number;
 }
 
+interface ExpenseOption {
+  id: string;
+  full_number: string;
+  description: string;
+  date: Date | string;
+  due_date: Date | string | null;
+  total: number;
+  already_paid: number;
+  remaining: number;
+  category_id: string;
+  category_name: string;
+  supplier_id: string | null;
+  supplier_name: string;
+}
+
+type PaymentTarget = 'invoice' | 'expense';
+
 type PaymentMethod = keyof typeof PAYMENT_METHOD_LABELS;
 
 interface ItemDraft {
   invoice_id: string | null;
+  expense_id: string | null;
   invoice_label: string | null;
   amount: string;
 }
@@ -166,6 +186,7 @@ export interface PaymentOrderEditData {
   full_number: string;
   items: Array<{
     invoice_id: string | null;
+    expense_id: string | null;
     invoice_label: string | null;
     amount: string;
   }>;
@@ -250,12 +271,18 @@ export function NewPaymentOrderForm({
     initialData?.scheduled_payment_date ?? ''
   );
   const [notes, setNotes] = useState(initialData?.notes ?? '');
+  const [paymentTarget, setPaymentTarget] = useState<PaymentTarget>('invoice');
   const [pendingInvoices, setPendingInvoices] = useState<InvoiceOption[] | null>(null);
+  const [pendingExpenses, setPendingExpenses] = useState<ExpenseOption[] | null>(null);
   const [posFilter, setPosFilter] = useState('');
+  const [expenseCategoryFilter, setExpenseCategoryFilter] = useState('');
+  const [expenseDueDateFilter, setExpenseDueDateFilter] = useState('');
+  const [expenseCategories, setExpenseCategories] = useState<{ id: string; name: string }[]>([]);
   const [supplierPaymentMethods, setSupplierPaymentMethods] = useState<
     SupplierPaymentMethodOpt[]
   >([]);
   const isLoadingInvoices = !!supplierId && pendingInvoices === null;
+  const isLoadingExpenses = pendingExpenses === null;
 
   const pointsOfSale = useMemo(() => {
     if (!pendingInvoices) return [];
@@ -268,6 +295,19 @@ export function NewPaymentOrderForm({
     return pendingInvoices.filter((i) => i.point_of_sale === posFilter);
   }, [pendingInvoices, posFilter]);
 
+  const filteredExpenses = useMemo(() => {
+    if (!pendingExpenses) return null;
+    let result = pendingExpenses;
+    if (expenseCategoryFilter) {
+      result = result.filter((e) => e.category_id === expenseCategoryFilter);
+    }
+    if (expenseDueDateFilter) {
+      const filterDate = new Date(expenseDueDateFilter);
+      result = result.filter((e) => e.due_date && new Date(e.due_date) <= filterDate);
+    }
+    return result;
+  }, [pendingExpenses, expenseCategoryFilter, expenseDueDateFilter]);
+
   const [items, setItems] = useState<ItemDraft[]>(initialData?.items ?? []);
   const [payments, setPayments] = useState<PaymentDraft[]>(
     initialData?.payments ?? [emptyPayment()]
@@ -278,17 +318,26 @@ export function NewPaymentOrderForm({
     if (!supplierId) {
       setSupplierPaymentMethods([]);
       setPosFilter('');
+      setPendingExpenses(null);
+      setExpenseCategoryFilter('');
+      setExpenseDueDateFilter('');
       return;
     }
     setPosFilter('');
+    setExpenseCategoryFilter('');
+    setExpenseDueDateFilter('');
     let cancelled = false;
     Promise.all([
       getPendingPurchaseInvoices(supplierId),
+      getPendingExpenses(supplierId),
+      getExpenseCategoriesForOrder(),
       getSupplierPaymentMethodsForPaymentOrder(supplierId),
     ])
-      .then(([invoices, methods]) => {
+      .then(([invoices, expenses, categories, methods]) => {
         if (cancelled) return;
         setPendingInvoices(invoices);
+        setPendingExpenses(expenses);
+        setExpenseCategories(categories);
         const opts = methods as SupplierPaymentMethodOpt[];
         setSupplierPaymentMethods(opts);
         // Auto-asignar default por línea según método (sin pisar selección existente)
@@ -300,6 +349,22 @@ export function NewPaymentOrderForm({
               pickDefaultMethodForPaymentMethod(opts, p.payment_method),
           }))
         );
+      })
+      .catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, [supplierId]);
+
+  // Cargar gastos y categorías cuando no hay proveedor seleccionado
+  useEffect(() => {
+    if (supplierId) return;
+    let cancelled = false;
+    Promise.all([getPendingExpenses(), getExpenseCategoriesForOrder()])
+      .then(([expenses, categories]) => {
+        if (cancelled) return;
+        setPendingExpenses(expenses);
+        setExpenseCategories(categories);
       })
       .catch(console.error);
     return () => {
@@ -324,6 +389,7 @@ export function NewPaymentOrderForm({
       if (amount <= 0) continue;
       draftItems.push({
         invoice_id: inv.id,
+        expense_id: null,
         invoice_label: inv.full_number,
         amount: amount.toFixed(2),
       });
@@ -353,6 +419,7 @@ export function NewPaymentOrderForm({
   const handleSupplierChange = (newId: string) => {
     if (newId !== supplierId) {
       setPendingInvoices(null);
+      setPendingExpenses(null);
       setSupplierPaymentMethods([]);
       setPayments((prev) =>
         prev.map((p) => ({ ...p, supplier_payment_method_id: null }))
@@ -438,14 +505,31 @@ export function NewPaymentOrderForm({
       ...prev,
       {
         invoice_id: invoice.id,
+        expense_id: null,
         invoice_label: invoice.full_number,
         amount: invoice.remaining.toFixed(2),
       },
     ]);
   };
 
+  const addExpenseItem = (expense: ExpenseOption) => {
+    if (items.some((i) => i.expense_id === expense.id)) {
+      toast.info('Ese gasto ya está agregado');
+      return;
+    }
+    setItems((prev) => [
+      ...prev,
+      {
+        invoice_id: null,
+        expense_id: expense.id,
+        invoice_label: expense.full_number,
+        amount: expense.remaining.toFixed(2),
+      },
+    ]);
+  };
+
   const addFreeItem = () => {
-    setItems((prev) => [...prev, { invoice_id: null, invoice_label: null, amount: '' }]);
+    setItems((prev) => [...prev, { invoice_id: null, expense_id: null, invoice_label: null, amount: '' }]);
   };
 
   const removeItem = (index: number) => {
@@ -457,14 +541,20 @@ export function NewPaymentOrderForm({
   };
 
   const selectedRemainingTotal = useMemo(() => {
-    if (!pendingInvoices) return 0;
-    const map = new Map(pendingInvoices.map((inv) => [inv.id, inv.remaining]));
+    const invoiceMap = new Map((pendingInvoices ?? []).map((inv) => [inv.id, inv.remaining]));
+    const expenseMap = new Map((pendingExpenses ?? []).map((exp) => [exp.id, exp.remaining]));
     return items.reduce((acc, it) => {
-      if (!it.invoice_id) return acc;
-      const remaining = map.get(it.invoice_id);
-      return remaining && remaining > 0 ? acc + remaining : acc;
+      if (it.invoice_id) {
+        const remaining = invoiceMap.get(it.invoice_id);
+        return remaining && remaining > 0 ? acc + remaining : acc;
+      }
+      if (it.expense_id) {
+        const remaining = expenseMap.get(it.expense_id);
+        return remaining && remaining > 0 ? acc + remaining : acc;
+      }
+      return acc;
     }, 0);
-  }, [items, pendingInvoices]);
+  }, [items, pendingInvoices, pendingExpenses]);
 
   const canLoadPendingBalance = selectedRemainingTotal > 0;
 
@@ -515,6 +605,7 @@ export function NewPaymentOrderForm({
         notes: notes.trim() || null,
         items: items.map((i) => ({
           invoice_id: i.invoice_id,
+          expense_id: i.expense_id,
           amount: i.amount.trim(),
         })),
         payments: payments.map((p) => ({
@@ -598,95 +689,192 @@ export function NewPaymentOrderForm({
         </CardContent>
       </Card>
 
-      {supplierId && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Facturas pendientes del proveedor</CardTitle>
-            <CardDescription>Clic en &quot;Agregar&quot; para imputar una factura a esta orden.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoadingInvoices ? (
-              <p className="text-sm text-muted-foreground">Cargando...</p>
-            ) : !pendingInvoices || pendingInvoices.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Sin facturas pendientes.</p>
-            ) : (<>
-              {pointsOfSale.length > 1 && (
-                <div className="mb-4 flex items-center gap-2">
-                  <Label className="text-xs whitespace-nowrap">Punto de venta</Label>
-                  <Select value={posFilter || '_all'} onValueChange={(v) => setPosFilter(v === '_all' ? '' : v)}>
-                    <SelectTrigger className="w-[180px]">
-                      <SelectValue placeholder="Todos" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="_all">Todos</SelectItem>
-                      {pointsOfSale.map((pos) => (
-                        <SelectItem key={pos} value={pos}>
-                          {pos.padStart(5, '0')}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Documentos a pagar</CardTitle>
+              <CardDescription>Seleccioná si vas a pagar una factura o un gasto.</CardDescription>
+            </div>
+            <Select value={paymentTarget} onValueChange={(v) => setPaymentTarget(v as PaymentTarget)}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="invoice">Facturas</SelectItem>
+                <SelectItem value="expense">Gastos</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {paymentTarget === 'invoice' ? (
+            <>
+              {!supplierId ? (
+                <p className="text-sm text-muted-foreground">Seleccioná un proveedor para ver facturas pendientes.</p>
+              ) : isLoadingInvoices ? (
+                <p className="text-sm text-muted-foreground">Cargando...</p>
+              ) : !pendingInvoices || pendingInvoices.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Sin facturas pendientes.</p>
+              ) : (<>
+                {pointsOfSale.length > 1 && (
+                  <div className="mb-4 flex items-center gap-2">
+                    <Label className="text-xs whitespace-nowrap">Punto de venta</Label>
+                    <Select value={posFilter || '_all'} onValueChange={(v) => setPosFilter(v === '_all' ? '' : v)}>
+                      <SelectTrigger className="w-[180px]">
+                        <SelectValue placeholder="Todos" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="_all">Todos</SelectItem>
+                        {pointsOfSale.map((pos) => (
+                          <SelectItem key={pos} value={pos}>
+                            {pos.padStart(5, '0')}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Factura</TableHead>
+                        <TableHead>Emisión</TableHead>
+                        <TableHead>Vto</TableHead>
+                        <TableHead className="text-right">Total</TableHead>
+                        <TableHead className="text-right">Ya pagado</TableHead>
+                        <TableHead className="text-right">Saldo</TableHead>
+                        <TableHead className="w-[100px]"></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {(filteredInvoices ?? []).map((inv) => {
+                        const added = items.some((i) => i.invoice_id === inv.id);
+                        return (
+                          <TableRow key={inv.id}>
+                            <TableCell className="font-mono">{inv.full_number}</TableCell>
+                            <TableCell className="text-sm">
+                              {format(new Date(inv.issue_date), 'dd/MM/yyyy')}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {inv.due_date ? format(new Date(inv.due_date), 'dd/MM/yyyy') : '-'}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">
+                              ${inv.total.toFixed(2)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm text-muted-foreground">
+                              ${inv.already_paid.toFixed(2)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono font-semibold">
+                              ${inv.remaining.toFixed(2)}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                size="sm"
+                                variant={added ? 'secondary' : 'default'}
+                                onClick={() => addInvoiceItem(inv)}
+                                disabled={added}
+                              >
+                                {added ? 'Agregada' : 'Agregar'}
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+              </>)}
+            </>
+          ) : (
+            <>
+              <div className="mb-4 flex flex-wrap items-center gap-3">
+                {expenseCategories.length > 0 && (
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs whitespace-nowrap">Categoría</Label>
+                    <Select value={expenseCategoryFilter || '_all'} onValueChange={(v) => setExpenseCategoryFilter(v === '_all' ? '' : v)}>
+                      <SelectTrigger className="w-[200px]">
+                        <SelectValue placeholder="Todas" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="_all">Todas</SelectItem>
+                        {expenseCategories.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <div className="flex items-center gap-2">
+                  <Label className="text-xs whitespace-nowrap">Vence antes de</Label>
+                  <Input
+                    type="date"
+                    className="w-[160px]"
+                    value={expenseDueDateFilter}
+                    onChange={(e) => setExpenseDueDateFilter(e.target.value)}
+                  />
+                </div>
+              </div>
+              {isLoadingExpenses ? (
+                <p className="text-sm text-muted-foreground">Cargando...</p>
+              ) : !filteredExpenses || filteredExpenses.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Sin gastos pendientes.</p>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Número</TableHead>
+                        <TableHead>Descripción</TableHead>
+                        <TableHead>Categoría</TableHead>
+                        <TableHead>Proveedor</TableHead>
+                        <TableHead>Vto</TableHead>
+                        <TableHead className="text-right">Total</TableHead>
+                        <TableHead className="text-right">Saldo</TableHead>
+                        <TableHead className="w-[100px]"></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredExpenses.map((exp) => {
+                        const added = items.some((i) => i.expense_id === exp.id);
+                        return (
+                          <TableRow key={exp.id}>
+                            <TableCell className="font-mono">{exp.full_number}</TableCell>
+                            <TableCell className="text-sm max-w-[200px] truncate">{exp.description}</TableCell>
+                            <TableCell className="text-sm">{exp.category_name}</TableCell>
+                            <TableCell className="text-sm">{exp.supplier_name || '-'}</TableCell>
+                            <TableCell className="text-sm">
+                              {exp.due_date ? format(new Date(exp.due_date), 'dd/MM/yyyy') : '-'}
+                            </TableCell>
+                            <TableCell className="text-right font-mono text-sm">${exp.total.toFixed(2)}</TableCell>
+                            <TableCell className="text-right font-mono font-semibold">${exp.remaining.toFixed(2)}</TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                size="sm"
+                                variant={added ? 'secondary' : 'default'}
+                                onClick={() => addExpenseItem(exp)}
+                                disabled={added}
+                              >
+                                {added ? 'Agregado' : 'Agregar'}
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
                 </div>
               )}
-              <div className="rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Factura</TableHead>
-                      <TableHead>Emisión</TableHead>
-                      <TableHead>Vto</TableHead>
-                      <TableHead className="text-right">Total</TableHead>
-                      <TableHead className="text-right">Ya pagado</TableHead>
-                      <TableHead className="text-right">Saldo</TableHead>
-                      <TableHead className="w-[100px]"></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {(filteredInvoices ?? []).map((inv) => {
-                      const added = items.some((i) => i.invoice_id === inv.id);
-                      return (
-                        <TableRow key={inv.id}>
-                          <TableCell className="font-mono">{inv.full_number}</TableCell>
-                          <TableCell className="text-sm">
-                            {format(new Date(inv.issue_date), 'dd/MM/yyyy')}
-                          </TableCell>
-                          <TableCell className="text-sm">
-                            {inv.due_date ? format(new Date(inv.due_date), 'dd/MM/yyyy') : '-'}
-                          </TableCell>
-                          <TableCell className="text-right font-mono text-sm">
-                            ${inv.total.toFixed(2)}
-                          </TableCell>
-                          <TableCell className="text-right font-mono text-sm text-muted-foreground">
-                            ${inv.already_paid.toFixed(2)}
-                          </TableCell>
-                          <TableCell className="text-right font-mono font-semibold">
-                            ${inv.remaining.toFixed(2)}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Button
-                              size="sm"
-                              variant={added ? 'secondary' : 'default'}
-                              onClick={() => addInvoiceItem(inv)}
-                              disabled={added}
-                            >
-                              {added ? 'Agregada' : 'Agregar'}
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </div>
-            </>)}
-          </CardContent>
-        </Card>
-      )}
+            </>
+          )}
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
-            <CardTitle>Ítems ({items.length})</CardTitle>
+            <CardTitle>{paymentTarget === 'expense' ? 'Gastos' : 'Facturas'} ({items.length})</CardTitle>
             <CardDescription>Importes a pagar — total: ${itemsTotal.toFixed(2)}</CardDescription>
           </div>
           <Button size="sm" variant="outline" onClick={addFreeItem}>
@@ -697,14 +885,14 @@ export function NewPaymentOrderForm({
         <CardContent>
           {items.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              Agregá facturas del listado de arriba o un ítem libre.
+              Agregá facturas o gastos del listado de arriba, o un ítem libre.
             </p>
           ) : (
             <div className="rounded-md border">
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Factura</TableHead>
+                    <TableHead>Documento</TableHead>
                     <TableHead className="text-right w-[180px]">Monto</TableHead>
                     <TableHead className="w-[50px]"></TableHead>
                   </TableRow>
@@ -713,8 +901,10 @@ export function NewPaymentOrderForm({
                   {items.map((item, idx) => (
                     <TableRow key={idx}>
                       <TableCell className="font-mono">
-                        {item.invoice_label ?? (
-                          <Badge variant="outline">Sin factura</Badge>
+                        {item.invoice_label ? (
+                          <span>{item.invoice_label}{item.expense_id ? <Badge variant="secondary" className="ml-2 text-xs">Gasto</Badge> : null}</span>
+                        ) : (
+                          <Badge variant="outline">Sin documento</Badge>
                         )}
                       </TableCell>
                       <TableCell className="text-right">
@@ -1065,7 +1255,7 @@ export function NewPaymentOrderForm({
           <div className="text-sm">
             <div className="flex flex-wrap gap-x-6 gap-y-1">
               <div>
-                <span className="text-muted-foreground">Total facturas:</span>{' '}
+                <span className="text-muted-foreground">Total {paymentTarget === 'expense' ? 'gastos' : 'facturas'}:</span>{' '}
                 <span className="font-mono font-semibold">${itemsTotal.toFixed(2)}</span>
               </div>
               {retentionsTotal > 0 && (

--- a/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
+++ b/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
@@ -109,17 +109,26 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
               {order.items.map((item) => (
                 <TableRow key={item.id}>
                   <TableCell className="font-mono">
-                    {item.invoice?.full_number ?? (
-                      <span className="text-muted-foreground">Pago sin factura</span>
+                    {item.invoice?.full_number
+                      ?? item.expense?.full_number
+                      ?? (<span className="text-muted-foreground">Pago sin documento</span>)}
+                    {item.expense && (
+                      <span className="ml-2 inline-flex items-center rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">Gasto</span>
                     )}
                   </TableCell>
                   <TableCell className="text-sm">
                     {item.invoice?.issue_date
                       ? format(new Date(item.invoice.issue_date), 'dd/MM/yyyy')
-                      : '-'}
+                      : item.expense?.date
+                        ? format(new Date(item.expense.date), 'dd/MM/yyyy')
+                        : '-'}
                   </TableCell>
                   <TableCell className="text-sm font-mono">
-                    {item.invoice ? `$${item.invoice.total.toFixed(2)}` : '-'}
+                    {item.invoice
+                      ? `$${item.invoice.total.toFixed(2)}`
+                      : item.expense
+                        ? `$${item.expense.amount.toFixed(2)}`
+                        : '-'}
                   </TableCell>
                   <TableCell className="text-right font-mono font-semibold">
                     ${item.amount.toFixed(2)}

--- a/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
+++ b/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
@@ -51,6 +51,15 @@ export async function sendPaymentOrderPaidEmail(
                 total: true,
               },
             },
+            expense: {
+              select: {
+                full_number: true,
+                description: true,
+                date: true,
+                due_date: true,
+                amount: true,
+              },
+            },
           },
         },
         payments: {
@@ -148,6 +157,16 @@ export async function sendPaymentOrderPaidEmail(
           issueDate: it.invoice!.issue_date,
           dueDate: it.invoice!.due_date,
           total: Number(it.invoice!.total),
+          appliedAmount: Number(it.amount),
+        })),
+      expenses: order.items
+        .filter((it) => it.expense)
+        .map((it) => ({
+          fullNumber: it.expense!.full_number,
+          description: it.expense!.description,
+          date: it.expense!.date,
+          dueDate: it.expense!.due_date,
+          total: Number(it.expense!.amount),
           appliedAmount: Number(it.amount),
         })),
       payments: order.payments.map((p) => ({

--- a/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
@@ -42,6 +42,7 @@ export function PaymentOrderTemplate({ data }: { data: PaymentOrderPDFData }) {
     paymentOrder,
     supplier,
     invoices,
+    expenses,
     payments,
     retentions = [],
     totalAmount,
@@ -130,6 +131,32 @@ export function PaymentOrderTemplate({ data }: { data: PaymentOrderPDFData }) {
                   <Text style={styles.invCurrency}>ARS</Text>
                   <Text style={styles.invTotal}>{fmtAmount(inv.total)}</Text>
                   <Text style={styles.invApplied}>{fmtAmount(inv.appliedAmount)}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {expenses.length > 0 ? (
+          <View>
+            <Text style={styles.sectionTitle}>Gastos a Cancelar</Text>
+            <View style={styles.table}>
+              <View style={styles.tableHeader}>
+                <Text style={styles.invDate}>Fecha</Text>
+                <Text style={styles.invDue}>Vencimiento</Text>
+                <Text style={styles.invVoucher}>Comprobante</Text>
+                <Text style={styles.invCurrency}>Descripción</Text>
+                <Text style={styles.invTotal}>Total</Text>
+                <Text style={styles.invApplied}>Importe aplicado</Text>
+              </View>
+              {expenses.map((exp, i) => (
+                <View key={i} style={styles.tableRow}>
+                  <Text style={styles.invDate}>{fmtDate(exp.date)}</Text>
+                  <Text style={styles.invDue}>{fmtDate(exp.dueDate)}</Text>
+                  <Text style={styles.invVoucher}>{exp.fullNumber}</Text>
+                  <Text style={styles.invCurrency}>{exp.description}</Text>
+                  <Text style={styles.invTotal}>{fmtAmount(exp.total)}</Text>
+                  <Text style={styles.invApplied}>{fmtAmount(exp.appliedAmount)}</Text>
                 </View>
               ))}
             </View>
@@ -228,7 +255,7 @@ export function PaymentOrderTemplate({ data }: { data: PaymentOrderPDFData }) {
         ) : null}
 
         <View style={styles.grandTotal}>
-          <Text>TOTAL FACTURAS</Text>
+          <Text>{expenses.length > 0 && invoices.length === 0 ? 'TOTAL GASTOS' : 'TOTAL FACTURAS'}</Text>
           <Text>{fmtAmount(totalAmount)}</Text>
         </View>
 

--- a/src/modules/treasury/features/payment-orders/shared/pdf/types.ts
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/types.ts
@@ -8,6 +8,15 @@ export interface PaymentOrderPDFInvoice {
   appliedAmount: number;
 }
 
+export interface PaymentOrderPDFExpense {
+  fullNumber: string;
+  description: string;
+  date: Date | string | null;
+  dueDate: Date | string | null;
+  total: number;
+  appliedAmount: number;
+}
+
 export type PaymentOrderPDFDestination =
   | {
       kind: 'ACCOUNT';
@@ -61,6 +70,7 @@ export interface PaymentOrderPDFData {
     email?: string;
   };
   invoices: PaymentOrderPDFInvoice[];
+  expenses: PaymentOrderPDFExpense[];
   payments: PaymentOrderPDFPayment[];
   retentions?: PaymentOrderPDFRetention[];
   totalAmount: number;

--- a/src/modules/treasury/shared/payment-order-validators.ts
+++ b/src/modules/treasury/shared/payment-order-validators.ts
@@ -7,6 +7,7 @@ const amountString = z
 
 export const paymentOrderItemSchema = z.object({
   invoice_id: z.string().uuid().optional().nullable(),
+  expense_id: z.string().uuid().optional().nullable(),
   amount: amountString.refine((v) => parseFloat(v) > 0, 'Debe ser mayor a 0'),
 });
 export type PaymentOrderItemFormData = z.infer<typeof paymentOrderItemSchema>;

--- a/supabase/migrations/20260515113719_add_expenses_module.sql
+++ b/supabase/migrations/20260515113719_add_expenses_module.sql
@@ -1,0 +1,67 @@
+-- Enum para estado de gasto
+CREATE TYPE expense_status AS ENUM ('DRAFT', 'CONFIRMED', 'PARTIAL_PAID', 'PAID', 'CANCELLED');
+
+-- Categorias de gastos
+CREATE TABLE expense_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id uuid NOT NULL REFERENCES company(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(company_id, name)
+);
+
+-- Gastos
+CREATE TABLE expenses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id uuid NOT NULL REFERENCES company(id) ON DELETE CASCADE,
+  number integer NOT NULL,
+  full_number text NOT NULL,
+  description text NOT NULL,
+  amount numeric(15,2) NOT NULL,
+  date date NOT NULL,
+  due_date date,
+  status expense_status NOT NULL DEFAULT 'DRAFT',
+  notes text,
+  category_id uuid NOT NULL REFERENCES expense_categories(id),
+  supplier_id uuid REFERENCES suppliers(id),
+  created_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(company_id, number)
+);
+
+-- Adjuntos de gastos
+CREATE TABLE expense_attachments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  expense_id uuid NOT NULL REFERENCES expenses(id) ON DELETE CASCADE,
+  file_name text NOT NULL,
+  file_key text NOT NULL,
+  file_size integer,
+  mime_type text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Extender payment_order_items para soportar gastos
+ALTER TABLE payment_order_items
+  ADD COLUMN expense_id uuid REFERENCES expenses(id);
+
+-- Indices
+CREATE INDEX idx_expenses_company_id ON expenses(company_id);
+CREATE INDEX idx_expenses_category_id ON expenses(category_id);
+CREATE INDEX idx_expenses_supplier_id ON expenses(supplier_id);
+CREATE INDEX idx_expenses_status ON expenses(status);
+CREATE INDEX idx_expense_categories_company_id ON expense_categories(company_id);
+CREATE INDEX idx_expense_attachments_expense_id ON expense_attachments(expense_id);
+CREATE INDEX idx_payment_order_items_expense_id ON payment_order_items(expense_id);
+
+-- Permisos del módulo de gastos
+INSERT INTO permissions (code, module, action, description) VALUES
+  ('compras.gastos.view', 'compras', 'view', 'Ver gastos'),
+  ('compras.gastos.create', 'compras', 'create', 'Crear gastos'),
+  ('compras.gastos.update', 'compras', 'update', 'Editar gastos'),
+  ('compras.gastos.confirm', 'compras', 'confirm', 'Confirmar gastos'),
+  ('compras.gastos.delete', 'compras', 'delete', 'Eliminar gastos')
+ON CONFLICT (code) DO NOTHING;


### PR DESCRIPTION
Nuevo módulo de gastos: CRUD completo con categorías, estados (borrador→confirmado→pagado), DataTable con filtros y export.

Integración con OP: selector factura/gasto, filtros por categoría y vencimiento, pago de gastos con actualización de estado automática, detalle en PDF y email.

Incluye migración DB (3 tablas + enum + FK en payment_order_items) y 5 permisos (compras.gastos.*).