### PR TITLE
fix(suppliers): CBU o alias requerido en cuentas de proveedor

### DIFF
--- a/src/modules/suppliers/features/create/components/SupplierPaymentMethodsField.tsx
+++ b/src/modules/suppliers/features/create/components/SupplierPaymentMethodsField.tsx
@@ -196,7 +196,7 @@ export default function SupplierPaymentMethodsField({ control }: Props) {
                   name={`payment_methods.${index}.cbu` as const}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>CBU *</FormLabel>
+                      <FormLabel>CBU</FormLabel>
                       <FormControl>
                         <Input
                           inputMode="numeric"
@@ -207,7 +207,7 @@ export default function SupplierPaymentMethodsField({ control }: Props) {
                           onChange={(e) => field.onChange(parseCbuInput(e.target.value))}
                         />
                       </FormControl>
-                      <p className="text-xs text-muted-foreground">22 dígitos numéricos</p>
+                      <p className="text-xs text-muted-foreground">CBU o alias: al menos uno requerido</p>
                       <FormMessage />
                     </FormItem>
                   )}
@@ -219,8 +219,9 @@ export default function SupplierPaymentMethodsField({ control }: Props) {
                     <FormItem>
                       <FormLabel>Alias</FormLabel>
                       <FormControl>
-                        <Input placeholder="alias.opcional" {...field} value={(field.value as string) ?? ''} />
+                        <Input placeholder="alias.cuenta" {...field} value={(field.value as string) ?? ''} />
                       </FormControl>
+                      <p className="text-xs text-muted-foreground">CBU o alias: al menos uno requerido</p>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/src/modules/suppliers/shared/validators.ts
+++ b/src/modules/suppliers/shared/validators.ts
@@ -15,7 +15,11 @@ const supplierPaymentMethodAccountSchema = z.object({
   account_holder: z.string().min(1, 'El titular es requerido').max(200),
   account_holder_tax_id: z.string().regex(cuitRegex, 'CUIT del titular inválido (formato: XX-XXXXXXXX-X)'),
   account_type: z.enum(['CHECKING', 'SAVINGS']),
-  cbu: z.string().regex(/^\d{22}$/, 'El CBU debe tener exactamente 22 dígitos'),
+  cbu: z
+    .string()
+    .regex(/^\d{22}$/, 'El CBU debe tener exactamente 22 dígitos')
+    .optional()
+    .or(z.literal('')),
   alias: z.string().max(50).optional().or(z.literal('')),
   currency: z.enum(['ARS', 'USD']).default('ARS'),
   is_default: z.boolean().default(false),
@@ -47,6 +51,16 @@ export const supplierPaymentMethodsArraySchema = z
         path: [],
       });
     }
+    // En cuentas, debe haber CBU o alias (al menos uno)
+    items.forEach((item, index) => {
+      if (item.type === 'ACCOUNT' && !item.cbu && !item.alias) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Debe ingresar el CBU o el alias',
+          path: [index, 'cbu'],
+        });
+      }
+    });
   });
 
 export const createSupplierSchema = z.object({


### PR DESCRIPTION
El CBU era obligatorio. Ahora se exige al menos uno de los dos (CBU o alias) para guardar una cuenta bancaria.