### PR TITLE
fix(descargas): tsk-210 servir descargas con Content-Type real

### DIFF
--- a/src/modules/documents/features/list/components/DocumentRowActions.tsx
+++ b/src/modules/documents/features/list/components/DocumentRowActions.tsx
@@ -23,6 +23,7 @@ import { DotsVerticalIcon } from '@radix-ui/react-icons';
 import { formatRelative } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { saveAs } from 'file-saver';
+import { blobWithResolvedType } from '@/shared/lib/mime';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -41,8 +42,8 @@ export function DocumentRowActions({ row }: DocumentRowActionsProps) {
       async () => {
         const data = await storage.download('document_files', path);
         const extension = path.split('.').pop();
-        const blob = new Blob([data], { type: 'application/octet-stream' });
-        saveAs(blob, `${resourceName} ${fileName}.${extension}`);
+        const outName = `${resourceName} ${fileName}.${extension}`;
+        saveAs(blobWithResolvedType(data, outName), outName);
       },
       {
         loading: 'Descargando documento...',

--- a/src/modules/documents/features/list/components/DownloadButton.tsx
+++ b/src/modules/documents/features/list/components/DownloadButton.tsx
@@ -5,6 +5,7 @@ import { DownloadIcon } from '@radix-ui/react-icons';
 import { saveAs } from 'file-saver';
 import { toast } from 'sonner';
 import { storage } from '@/shared/lib/storage';
+import { blobWithResolvedType } from '@/shared/lib/mime';
 function DownloadButton({ path, fileName }: { path: string; fileName: string }) {
   const handleDownload = async (path: string, fileName: string) => {
     toast.promise(
@@ -14,9 +15,10 @@ function DownloadButton({ path, fileName }: { path: string; fileName: string }) 
         // Extrae la extensión del archivo del path
         const extension = path.split('.').pop();
 
-        const blob = new Blob([data], { type: 'application/octet-stream' });
-        // Usa la extensión del archivo al guardar el archivo
-        saveAs(blob, `${fileName}CodeControl.${extension}`);
+        const outName = `${fileName}CodeControl.${extension}`;
+        // Descarga con el Content-Type real (no octet-stream) para no disparar
+        // la cuarentena de antivirus como McAfee.
+        saveAs(blobWithResolvedType(data, outName), outName);
       },
       {
         loading: 'Descargando documento...',

--- a/src/modules/documents/features/list/components/EquipmentDocumentRowActions.tsx
+++ b/src/modules/documents/features/list/components/EquipmentDocumentRowActions.tsx
@@ -23,6 +23,7 @@ import { DotsVerticalIcon } from '@radix-ui/react-icons';
 import { formatRelative } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { saveAs } from 'file-saver';
+import { blobWithResolvedType } from '@/shared/lib/mime';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -41,8 +42,8 @@ export function EquipmentDocumentRowActions({ row }: EquipmentDocumentRowActions
       async () => {
         const data = await storage.download('document_files', path);
         const extension = path.split('.').pop();
-        const blob = new Blob([data], { type: 'application/octet-stream' });
-        saveAs(blob, `${resourceName} ${fileName}.${extension}`);
+        const outName = `${resourceName} ${fileName}.${extension}`;
+        saveAs(blobWithResolvedType(data, outName), outName);
       },
       {
         loading: 'Descargando documento...',

--- a/src/modules/documents/features/list/components/columns.tsx
+++ b/src/modules/documents/features/list/components/columns.tsx
@@ -33,6 +33,7 @@ import {
   DropdownMenuTrigger,
 } from '@/shared/components/ui/dropdown-menu';
 import { saveAs } from 'file-saver';
+import { resolveDownloadType } from '@/shared/lib/mime';
 
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/shared/components/ui/form';
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/components/ui/popover';
@@ -105,7 +106,7 @@ export const columns: ColumnDef<Colum>[] = [
             // Extrae la extensión del archivo del path
             const extension = path.split('.').pop();
 
-            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const blob = new Blob([data], { type: resolveDownloadType(data.type, path) });
             // Usa la extensión del archivo al guardar el archivo
             saveAs(blob, `${resourceName} ${fileName}.${extension}`);
           },

--- a/src/modules/documents/features/list/components/columnsEmployee.tsx
+++ b/src/modules/documents/features/list/components/columnsEmployee.tsx
@@ -39,6 +39,7 @@ import { Table, TableBody, TableCell, TableHeader, TableRow } from '@/shared/com
 import { useEdgeFunctions } from '@/shared/hooks/useEdgeFunctions';
 import { cn } from '@/shared/lib/utils';
 import { saveAs } from 'file-saver';
+import { resolveDownloadType } from '@/shared/lib/mime';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DotsVerticalIcon } from '@radix-ui/react-icons';
@@ -104,7 +105,7 @@ export const columEmp: ColumnDef<Colum>[] = [
             // Extrae la extensión del archivo del path
             const extension = path.split('.').pop();
 
-            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const blob = new Blob([data], { type: resolveDownloadType(data.type, path) });
             // Usa la extensión del archivo al guardar el archivo
             saveAs(blob, `${resourceName} ${fileName}.${extension}`);
           },

--- a/src/modules/documents/shared/columns/ColumnsMonthly.tsx
+++ b/src/modules/documents/shared/columns/ColumnsMonthly.tsx
@@ -49,6 +49,7 @@ import { ColumnDef, FilterFn, Row } from '@tanstack/react-table';
 import { addMonths, format, formatRelative } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { saveAs } from 'file-saver';
+import { resolveDownloadType } from '@/shared/lib/mime';
 import { ArrowUpDown, CheckCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -137,7 +138,7 @@ export const ColumnsMonthly: ColumnDef<Colum>[] = [
             // Extrae la extensión del archivo del path
             const extension = path.split('.').pop();
 
-            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const blob = new Blob([data], { type: resolveDownloadType(data.type, path) });
             // Usa la extensión del archivo al guardar el archivo
             saveAs(blob, `${resourceName} ${fileName}.${extension}`);
           },

--- a/src/modules/documents/shared/columns/ColumnsMonthlyEquipment.tsx
+++ b/src/modules/documents/shared/columns/ColumnsMonthlyEquipment.tsx
@@ -49,6 +49,7 @@ import { ColumnDef, FilterFn, Row } from '@tanstack/react-table';
 import { addMonths, format, formatRelative } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { saveAs } from 'file-saver';
+import { resolveDownloadType } from '@/shared/lib/mime';
 import { ArrowUpDown, CheckCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -137,7 +138,7 @@ export const ColumnsMonthlyEquipment: ColumnDef<Colum>[] = [
             // Extrae la extensión del archivo del path
             const extension = path.split('.').pop();
 
-            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const blob = new Blob([data], { type: resolveDownloadType(data.type, path) });
             // Usa la extensión del archivo al guardar el archivo
             saveAs(blob, `${resourceName} ${fileName}.${extension}`);
           },

--- a/src/modules/documents/shared/columns/ExpiredColumns.tsx
+++ b/src/modules/documents/shared/columns/ExpiredColumns.tsx
@@ -13,6 +13,7 @@ import {
   AlertDialogTrigger,
 } from '@/shared/components/ui/alert-dialog';
 import { saveAs } from 'file-saver';
+import { resolveDownloadType } from '@/shared/lib/mime';
 
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
@@ -273,7 +274,7 @@ export const ExpiredColums: ColumnDef<any>[] = [
             // Extrae la extensión del archivo del path
             const extension = path.split('.').pop();
 
-            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const blob = new Blob([data], { type: resolveDownloadType(data.type, path) });
             // Usa la extensión del archivo al guardar el archivo
             saveAs(blob, `${resourceName} ${fileName}.${extension}`);
           },

--- a/src/modules/hse/features/documents/components/Document-section.tsx
+++ b/src/modules/hse/features/documents/components/Document-section.tsx
@@ -20,6 +20,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui
 import type { Document } from '../actions.server';
 import { DocumentUploadDialog } from './Document-upload-dialog';
 import { storage } from '@/shared/lib/storage';
+import { blobWithResolvedType } from '@/shared/lib/mime';
 import Cookies from 'js-cookie';
 import { Calendar, Download, Eye, FileText, LayoutGrid, List, Users } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -520,7 +521,7 @@ export function DocumentsSection({ initialDocuments, initialEmployees, allTags, 
     try {
       const data = await storage.download('documents-hse', file_path);
 
-      const url = window.URL.createObjectURL(data);
+      const url = window.URL.createObjectURL(blobWithResolvedType(data, file_name));
       const a = document.createElement('a');
       a.href = url;
       a.download = file_name;

--- a/src/shared/lib/download.ts
+++ b/src/shared/lib/download.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { storage } from "./storage"
+import { blobWithResolvedType } from "./mime"
 
 export async function downloadFile(filePath: string, fileName: string) {
   // Verificar si estamos en el navegador
@@ -12,7 +13,7 @@ export async function downloadFile(filePath: string, fileName: string) {
   try {
     const data = await storage.download('documents-hse', filePath)
 
-    const url = window.URL.createObjectURL(new Blob([data]))
+    const url = window.URL.createObjectURL(blobWithResolvedType(data, fileName))
     const link = document.createElement('a')
     link.href = url
     link.setAttribute('download', fileName)

--- a/src/shared/lib/mime.ts
+++ b/src/shared/lib/mime.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolución de Content-Type para descargas.
+ *
+ * Forzar `application/octet-stream` (binario genérico) en las descargas hace que
+ * algunos antivirus (p. ej. McAfee) las marquen como sospechosas y las manden a
+ * cuarentena. Estos helpers derivan el MIME real del archivo para que la
+ * descarga llegue declarada con su tipo correcto (application/pdf, image/jpeg…).
+ */
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  csv: 'text/csv',
+  txt: 'text/plain',
+  rtf: 'application/rtf',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  tiff: 'image/tiff',
+  svg: 'image/svg+xml',
+  zip: 'application/zip',
+  json: 'application/json',
+  xml: 'application/xml',
+};
+
+const GENERIC = 'application/octet-stream';
+
+/** MIME type a partir de la extensión del nombre de archivo. */
+export function mimeTypeForFilename(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  return MIME_BY_EXTENSION[ext] ?? GENERIC;
+}
+
+/**
+ * Type confiable para descargar un Blob: prioriza el Content-Type que ya trae el
+ * Blob (p. ej. el que devuelve Supabase Storage) cuando es específico, y si es
+ * genérico o vacío lo deriva de la extensión del nombre. Evita degradar a
+ * octet-stream.
+ */
+export function resolveDownloadType(blobType: string | undefined | null, filename: string): string {
+  if (blobType && blobType !== GENERIC) return blobType;
+  return mimeTypeForFilename(filename);
+}
+
+/**
+ * Reenvuelve un Blob descargado con su Content-Type correcto (si hace falta) para
+ * que la descarga quede declarada con el MIME real.
+ */
+export function blobWithResolvedType(data: Blob, filename: string): Blob {
+  const type = resolveDownloadType(data.type, filename);
+  if (data.type === type) return data;
+  return new Blob([data], { type });
+}


### PR DESCRIPTION
Las descargas client-side forzaban application/octet-stream (binario genérico), señal que dispara la cuarentena de antivirus como McAfee, y además pisaba el Content-Type real que ya devuelve Supabase Storage.

Nuevo helper src/shared/lib/mime.ts (resolveDownloadType / blobWithResolvedType) que entrega cada descarga con su MIME real (application/pdf, image/jpeg, etc.) derivándolo del tipo del Blob o de la extensión. Aplicado en los 10 puntos de descarga de documentos (empleados/equipos, columnas mensual/equipos/vencidos, HSE y el helper download.ts compartido). El ZIP y el export Excel ya usaban el tipo correcto.