### PR TITLE
feat(compras): tsk-212 eliminar factura de compra (solo owner)

### DIFF
--- a/src/modules/purchasing/features/invoices/list/actions.server.ts
+++ b/src/modules/purchasing/features/invoices/list/actions.server.ts
@@ -907,3 +907,58 @@ export async function updatePurchaseInvoiceReceivingStatus(invoiceId: string) {
     data: { receiving_status: newStatus },
   });
 }
+
+/**
+ * Elimina (borrado físico) una factura de compra, incluso confirmada.
+ * Restricciones:
+ *  - Solo el OWNER de la empresa puede hacerlo.
+ *  - Se bloquea si la factura tiene pagos imputados en una OP no anulada o
+ *    movimientos de caja asociados, para no dejar tesorería inconsistente.
+ * Las líneas/percepciones/otros cargos se borran en cascada (FK ON DELETE CASCADE);
+ * remitos de recepción y cuotas quedan desvinculados (ON DELETE SET NULL).
+ */
+export async function deletePurchaseInvoice(id: string) {
+  const { companyId } = await getActionContext();
+  if (!companyId) return { error: 'No company selected' };
+
+  const isOwner = await isActiveUserOwner();
+  if (!isOwner) {
+    return { error: 'Solo el dueño de la empresa puede eliminar facturas de compra' };
+  }
+
+  try {
+    const invoice = await prisma.purchase_invoices.findFirst({
+      where: { id, company_id: companyId },
+      select: { id: true, full_number: true },
+    });
+    if (!invoice) return { error: 'Factura no encontrada' };
+
+    // Bloqueo: pagos imputados (en OP no anulada) o movimientos de caja.
+    const [activePayment, cashMovement] = await Promise.all([
+      prisma.payment_order_items.findFirst({
+        where: { invoice_id: id, payment_order: { status: { not: 'CANCELLED' } } },
+        select: { payment_order: { select: { full_number: true } } },
+      }),
+      prisma.cash_movements.findFirst({
+        where: { purchase_invoice_id: id },
+        select: { id: true },
+      }),
+    ]);
+    if (activePayment) {
+      return {
+        error: `No se puede eliminar: la factura está imputada a la orden de pago ${activePayment.payment_order?.full_number ?? ''}. Anulá esa OP primero.`,
+      };
+    }
+    if (cashMovement) {
+      return { error: 'No se puede eliminar: la factura tiene movimientos de caja asociados.' };
+    }
+
+    await prisma.purchase_invoices.delete({ where: { id } });
+
+    revalidatePath('/dashboard/purchasing');
+    return { error: null };
+  } catch (error) {
+    console.error('Error deleting purchase invoice:', error);
+    return { error: String(error) };
+  }
+}

--- a/src/modules/purchasing/features/invoices/list/components/columns.tsx
+++ b/src/modules/purchasing/features/invoices/list/components/columns.tsx
@@ -10,63 +10,125 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/shared/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
 import { INVOICE_STATUS_LABELS, VOUCHER_TYPE_LABELS, INVOICE_RECEIVING_STATUS_LABELS, INVOICE_RECEIVING_STATUS_COLORS } from '@/modules/purchasing/shared/types';
-import { confirmPurchaseInvoice } from '../actions.server';
+import { confirmPurchaseInvoice, deletePurchaseInvoice } from '../actions.server';
 import { format } from 'date-fns';
-import { MoreHorizontal, Eye, CheckCircle, Pencil } from 'lucide-react';
+import { MoreHorizontal, Eye, CheckCircle, Pencil, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 function ActionsCell({ row, isOwner }: { row: any; isOwner: boolean }) {
   const router = useRouter();
   const status = row.original.status;
   const id = row.original.id;
+  const fullNumber = row.original.full_number;
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   // DRAFT: editable por cualquiera con acceso. CONFIRMED: solo el owner de la empresa.
   const canEdit = status === 'DRAFT' || (status === 'CONFIRMED' && isOwner);
 
+  const handleDelete = () => {
+    toast.promise(
+      async () => {
+        const result = await deletePurchaseInvoice(id);
+        if (result.error) throw new Error(result.error);
+        router.refresh();
+      },
+      { loading: 'Eliminando...', success: 'Factura eliminada', error: (e) => e.message }
+    );
+  };
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="size-8">
-          <MoreHorizontal className="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem asChild>
-          <Link href={`/dashboard/purchasing/invoices/${id}`}>
-            <Eye className="size-4 mr-2" /> Ver detalle
-          </Link>
-        </DropdownMenuItem>
-        {canEdit && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <Link href={`/dashboard/purchasing/invoices/${id}/edit`}>
-                <Pencil className="size-4 mr-2" /> Editar
-              </Link>
-            </DropdownMenuItem>
-          </>
-        )}
-        {status === 'DRAFT' && (
-          <DropdownMenuItem
-            onClick={() => {
-              toast.promise(
-                async () => {
-                  const result = await confirmPurchaseInvoice(id);
-                  if (result.error) throw new Error(result.error);
-                  router.refresh();
-                },
-                { loading: 'Confirmando...', success: 'Factura confirmada', error: (e) => e.message }
-              );
-            }}
-          >
-            <CheckCircle className="size-4 mr-2" /> Confirmar
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="size-8">
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link href={`/dashboard/purchasing/invoices/${id}`}>
+              <Eye className="size-4 mr-2" /> Ver detalle
+            </Link>
           </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {canEdit && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <Link href={`/dashboard/purchasing/invoices/${id}/edit`}>
+                  <Pencil className="size-4 mr-2" /> Editar
+                </Link>
+              </DropdownMenuItem>
+            </>
+          )}
+          {status === 'DRAFT' && (
+            <DropdownMenuItem
+              onClick={() => {
+                toast.promise(
+                  async () => {
+                    const result = await confirmPurchaseInvoice(id);
+                    if (result.error) throw new Error(result.error);
+                    router.refresh();
+                  },
+                  { loading: 'Confirmando...', success: 'Factura confirmada', error: (e) => e.message }
+                );
+              }}
+            >
+              <CheckCircle className="size-4 mr-2" /> Confirmar
+            </DropdownMenuItem>
+          )}
+          {isOwner && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setConfirmDeleteOpen(true);
+                }}
+              >
+                <Trash2 className="size-4 mr-2" /> Eliminar
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar factura {fullNumber}</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción elimina la factura de forma permanente, incluso si está confirmada. No se
+              puede deshacer. Si la factura tiene pagos imputados o movimientos de caja, el sistema
+              lo impedirá.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDelete}
+            >
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 


### PR DESCRIPTION
Solo el dueño de la empresa puede eliminar una factura de compra, incluso confirmada (borrado físico).

- Nueva server action deletePurchaseInvoice: valida isActiveUserOwner() y bloquea si la factura tiene pagos imputados en una OP no anulada o movimientos de caja, para no dejar tesorería inconsistente. Líneas / percepciones / otros cargos se borran en cascada; remitos y cuotas se desvinculan (ON DELETE SET NULL).
- UI: ítem "Eliminar" en el menú de acciones de la tabla de facturas, visible solo para el owner, con diálogo de confirmación. El isOwner ya se calcula server-side en InvoicesList.

Sin migración. check-types ok.