### PR TITLE
Dev

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2168,6 +2168,7 @@ enum payment_method {
   DEBIT_CARD
   CREDIT_CARD
   ACCOUNT
+  DEBIN_CREDIN
 }
 
 enum payment_order_status {

--- a/src/app/maintenance/[id]/page.tsx
+++ b/src/app/maintenance/[id]/page.tsx
@@ -99,6 +99,19 @@ export default async function Home({
     })
   ) as any[];
 
+  // Normalizar las solicitudes pendientes al shape que espera VehicleRepairRequests
+  // (reparation_type + equipment_id como objeto con brand/model). El include de
+  // Prisma las trae como reparation_type_rel + equipment(brand_rel/model_rel).
+  const pendingRequestsForView = serializeBigInt(
+    (pendingRepairs as any[]).map((r) => ({
+      ...r,
+      reparation_type: r.reparation_type_rel ?? null,
+      equipment_id: r.equipment
+        ? { ...r.equipment, brand: r.equipment.brand_rel ?? null, model: r.equipment.model_rel ?? null }
+        : null,
+    }))
+  ) as any;
+
   const vehiclesFormatted = setVehiclesToShow(equipments || []) || [];
 
   const equipmentsForComboBox = [
@@ -126,7 +139,7 @@ export default async function Home({
       tipo_de_mantenimiento={typesOfRepairs as unknown as TypeOfRepair}
       default_equipment_id={id}
       role={role}
-      pendingRequests={pendingRepairs as any}
+      pendingRequests={pendingRequestsForView}
       checkList={
         checklists
           .filter(

--- a/src/modules/equipment/features/qr/components/VehicleRepairRequests.tsx
+++ b/src/modules/equipment/features/qr/components/VehicleRepairRequests.tsx
@@ -56,27 +56,27 @@ export default function VehicleRepairRequests({
             <Card key={request.id}>
               <CardHeader>
                 <CardTitle className="flex justify-between items-center">
-                  <span className="text-xl">{request.reparation_type.name}</span>
+                  <span className="text-xl">{request.reparation_type?.name}</span>
                   <Badge
                     variant={
-                      request.reparation_type.criticity === 'Alta'
+                      request.reparation_type?.criticity === 'Alta'
                         ? 'destructive'
-                        : request.reparation_type.criticity === 'Media'
+                        : request.reparation_type?.criticity === 'Media'
                           ? 'yellow'
                           : 'outline'
                     }
                   >
-                    {request.reparation_type.criticity}
+                    {request.reparation_type?.criticity}
                   </Badge>
                 </CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <div>
-                    <strong>Dominio:</strong> {request.equipment_id.domain}
+                    <strong>Dominio:</strong> {request.equipment_id?.domain}
                   </div>
                   <div>
-                    <strong>Equipo:</strong> {request.equipment_id.brand.name} {request.equipment_id.model.name}
+                    <strong>Equipo:</strong> {request.equipment_id?.brand?.name} {request.equipment_id?.model?.name}
                   </div>
                   <div>
                     <strong>Fecha:</strong>{' '}
@@ -100,7 +100,7 @@ export default function VehicleRepairRequests({
       <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
         <DialogContent className="max-w-[90vw] w-full max-h-[90vh] overflow-y-auto rounded-lg">
           <DialogHeader>
-            <DialogTitle className="text-xl">{selectedRequest?.reparation_type.name}</DialogTitle>
+            <DialogTitle className="text-xl">{selectedRequest?.reparation_type?.name}</DialogTitle>
             <DialogDescription>Detalles de la reparacion y del vehiculo</DialogDescription>
           </DialogHeader>
           <Tabs defaultValue="vehicle" className="w-full">
@@ -112,31 +112,31 @@ export default function VehicleRepairRequests({
               <div className="grid gap-4 py-4">
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Marca:</span>
-                  <span>{selectedRequest?.equipment_id.brand.name}</span>
+                  <span>{selectedRequest?.equipment_id?.brand?.name}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Modelo:</span>
-                  <span>{selectedRequest?.equipment_id.model.name}</span>
+                  <span>{selectedRequest?.equipment_id?.model?.name}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Ano:</span>
-                  <span>{selectedRequest?.equipment_id.year}</span>
+                  <span>{selectedRequest?.equipment_id?.year}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Dominio:</span>
-                  <span>{selectedRequest?.equipment_id.domain}</span>
+                  <span>{selectedRequest?.equipment_id?.domain}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Numero interno:</span>
-                  <span>{selectedRequest?.equipment_id.intern_number}</span>
+                  <span>{selectedRequest?.equipment_id?.intern_number}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Kilometraje:</span>
-                  <span>{selectedRequest?.equipment_id.kilometer} km</span>
+                  <span>{selectedRequest?.equipment_id?.kilometer} km</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Condicion:</span>
-                  <span>{selectedRequest?.equipment_id.condition}</span>
+                  <span>{selectedRequest?.equipment_id?.condition}</span>
                 </div>
               </div>
             </TabsContent>
@@ -148,11 +148,11 @@ export default function VehicleRepairRequests({
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Prioridad:</span>
-                  <span>{selectedRequest?.reparation_type.criticity}</span>
+                  <span>{selectedRequest?.reparation_type?.criticity}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Tipo de mantenimiento:</span>
-                  <span>{selectedRequest?.reparation_type.type_of_maintenance}</span>
+                  <span>{selectedRequest?.reparation_type?.type_of_maintenance}</span>
                 </div>
                 <div className="grid grid-cols-2 items-center gap-4">
                   <span className="font-bold">Descripcion:</span>

--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -708,7 +708,7 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
 /**
  * Confirma una orden de pago. Por cada payment genera:
  *   - CASH → cash_movement tipo EXPENSE en la caja (requiere sesión abierta)
- *   - TRANSFER → bank_movement tipo TRANSFER_OUT + actualiza balance
+ *   - TRANSFER / DEBIN_CREDIN → bank_movement tipo TRANSFER_OUT + actualiza balance
  *   - DEBIT_CARD / CREDIT_CARD → bank_movement tipo DEBIT + actualiza balance
  *   - CHECK → solo queda registrado en payment_order_payments.check_number
  *     (el cheque propio se carga aparte desde el módulo de cheques)
@@ -770,10 +770,11 @@ export async function confirmPaymentOrder(id: string) {
       if (
         (p.payment_method === 'TRANSFER' ||
           p.payment_method === 'DEBIT_CARD' ||
-          p.payment_method === 'CREDIT_CARD') &&
+          p.payment_method === 'CREDIT_CARD' ||
+          p.payment_method === 'DEBIN_CREDIN') &&
         !p.bank_account_id
       ) {
-        return { error: 'Hay un pago con tarjeta/transferencia sin cuenta bancaria asignada' };
+        return { error: 'Hay un pago con tarjeta/transferencia/DEBIN/CREDIN sin cuenta bancaria asignada' };
       }
       if (p.bank_account_id) {
         const account = await prisma.bank_accounts.findUnique({
@@ -842,11 +843,16 @@ export async function confirmPaymentOrder(id: string) {
         if (
           (p.payment_method === 'TRANSFER' ||
             p.payment_method === 'DEBIT_CARD' ||
-            p.payment_method === 'CREDIT_CARD') &&
+            p.payment_method === 'CREDIT_CARD' ||
+            p.payment_method === 'DEBIN_CREDIN') &&
           p.bank_account_id
         ) {
+          // DEBIN/CREDIN y TRANSFER son transferencias electrónicas (TRANSFER_OUT);
+          // las tarjetas se registran como DEBIT. Todas restan del saldo de la cuenta.
           const movementType =
-            p.payment_method === 'TRANSFER' ? 'TRANSFER_OUT' : 'DEBIT';
+            p.payment_method === 'DEBIT_CARD' || p.payment_method === 'CREDIT_CARD'
+              ? 'DEBIT'
+              : 'TRANSFER_OUT';
 
           const account = await tx.bank_accounts.findUnique({
             where: { id: p.bank_account_id },

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
@@ -1080,7 +1080,7 @@ export function NewPaymentOrderForm({
                   </div>
                 )}
 
-                {['TRANSFER', 'DEBIT_CARD', 'CREDIT_CARD'].includes(p.payment_method) && (
+                {['TRANSFER', 'DEBIT_CARD', 'CREDIT_CARD', 'DEBIN_CREDIN'].includes(p.payment_method) && (
                   <div className="md:col-span-3 space-y-1.5">
                     <Label>Cuenta bancaria</Label>
                     <Select

--- a/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/PaymentOrderTemplate.tsx
@@ -12,6 +12,7 @@ const PAYMENT_METHOD_LABELS: Record<string, string> = {
   DEBIT_CARD: 'Tarjeta de débito',
   CREDIT_CARD: 'Tarjeta de crédito',
   ACCOUNT: 'Cuenta corriente',
+  DEBIN_CREDIN: 'DEBIN/CREDIN',
 };
 
 function fmtDate(d: Date | string | null | undefined): string {

--- a/src/modules/treasury/shared/payment-order-validators.ts
+++ b/src/modules/treasury/shared/payment-order-validators.ts
@@ -21,6 +21,7 @@ export const paymentOrderPaymentSchema = z
       'DEBIT_CARD',
       'CREDIT_CARD',
       'ACCOUNT',
+      'DEBIN_CREDIN',
     ]),
     amount: amountString.refine((v) => parseFloat(v) > 0, 'Debe ser mayor a 0'),
     cash_register_id: z.string().uuid().optional().nullable(),
@@ -41,7 +42,10 @@ export const paymentOrderPaymentSchema = z
         message: 'Seleccioná la caja para pagos en efectivo',
       });
     }
-    if (['TRANSFER', 'DEBIT_CARD', 'CREDIT_CARD'].includes(data.payment_method) && !data.bank_account_id) {
+    if (
+      ['TRANSFER', 'DEBIT_CARD', 'CREDIT_CARD', 'DEBIN_CREDIN'].includes(data.payment_method) &&
+      !data.bank_account_id
+    ) {
       ctx.addIssue({
         code: 'custom',
         path: ['bank_account_id'],

--- a/src/modules/treasury/shared/validators.ts
+++ b/src/modules/treasury/shared/validators.ts
@@ -114,6 +114,7 @@ export const PAYMENT_METHOD_LABELS = {
   DEBIT_CARD: 'Tarjeta de débito',
   CREDIT_CARD: 'Tarjeta de crédito',
   ACCOUNT: 'Cuenta corriente',
+  DEBIN_CREDIN: 'DEBIN/CREDIN',
 } as const;
 
 export const PAYMENT_ORDER_STATUS_LABELS = {

--- a/supabase/migrations/20260618213839_add_debin_credin_payment_method.sql
+++ b/supabase/migrations/20260618213839_add_debin_credin_payment_method.sql
@@ -1,0 +1,5 @@
+-- Agrega DEBIN/CREDIN como método de pago (TSK-282).
+-- Es un único medio de pago electrónico asociado a una cuenta bancaria; se
+-- comporta como una transferencia (egreso de la cuenta) en la Orden de Pago.
+
+ALTER TYPE "payment_method" ADD VALUE IF NOT EXISTS 'DEBIN_CREDIN';


### PR DESCRIPTION
[feat(tesoreria): tsk-282 método de pago DEBIN/CREDIN](https://github.com/fspiritosi/s-codeControl/commit/1ac7cb60479a04ece4bc57f5e705c11742fc6434) 

Nuevo método de pago único DEBIN/CREDIN (enum payment_method =
DEBIN_CREDIN, label "DEBIN/CREDIN"), asociado a una cuenta bancaria. Se
comporta como una transferencia: requiere cuenta, y al confirmar la OP
genera un bank_movement TRANSFER_OUT que descuenta el saldo. La anulación
ya lo revierte (TRANSFER_OUT -> TRANSFER_IN), sin cambios.

Migración aditiva (ALTER TYPE payment_method ADD VALUE DEBIN_CREDIN).
Tocado: schema, labels (validators + PDF), validators de pago, confirm
y el form. check-types ok.

### tarea 2: 

Los choferes veían "Algo salió mal" al abrir las solicitudes de un equipo
con reparaciones pendientes. Causa: /maintenance/[id] traía las solicitudes
con shape Prisma (reparation_type_rel, equipment.brand_rel/model_rel) pero
VehicleRepairRequests esperaba reparation_type y equipment_id.brand/model;
el .map accedía a undefined.name y disparaba el error boundary. El "as any"
ocultaba el desajuste.

- page.tsx: normaliza las solicitudes al shape esperado y las serializa.
- VehicleRepairRequests: optional chaining (defensa) en listado y modal.

Sin migración. check-types ok.

