### PR TITLE
perf(app): mejorar rendimiento de navegación (bundle + queries)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    // Tree-shaking selectivo: solo importa lo usado de estos paquetes, evita código muerto.
+    optimizePackageImports: [
+      'lucide-react',
+      'react-icons',
+      'recharts',
+      'date-fns',
+      '@radix-ui/react-icons'
+    ]
+  },
   images: {
     // domains: ['zktcbhhlcksopklpnubj.supabase.co', 'th.bing.com'],
     remotePatterns: [

--- a/src/app/admin/panel/page.tsx
+++ b/src/app/admin/panel/page.tsx
@@ -19,8 +19,13 @@ import { Separator } from '@/shared/components/ui/separator';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
 import { prisma } from '@/shared/lib/prisma';
-import { CompanieChart } from '@/modules/admin/features/panel/components/CompaniesChart';
+import dynamic from 'next/dynamic';
 import CreateUser from '@/modules/admin/features/panel/components/CreateUser';
+
+// Carga diferida: recharts (~45KB) sale del bundle inicial de la ruta.
+const CompanieChart = dynamic(() =>
+  import('@/modules/admin/features/panel/components/CompaniesChart').then((m) => m.CompanieChart)
+);
 
 export default async function Dashboard() {
   const company = await prisma.company.findMany();

--- a/src/app/dashboard/hse/detail/[id]/page.tsx
+++ b/src/app/dashboard/hse/detail/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { fetchAllTags, fetchTrainingById } from '@/modules/hse/features/training/actions.server';
-import TrainingDetail from '@/modules/hse/features/training/components/trainin-detail-wrapper';
+import dynamic from 'next/dynamic';
+
+// Carga diferida: recharts (~45KB) sale del bundle inicial de la ruta.
+const TrainingDetail = dynamic(() => import('@/modules/hse/features/training/components/trainin-detail-wrapper'));
 
 export default async function TrainingDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;

--- a/src/modules/admin/features/tables/components/TableCard.tsx
+++ b/src/modules/admin/features/tables/components/TableCard.tsx
@@ -13,7 +13,6 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/table';
 import { format } from 'date-fns';
 import { MoreHorizontal } from 'lucide-react';
-import * as XLSX from 'xlsx';
 
 type Props = {
   title: string;
@@ -22,7 +21,8 @@ type Props = {
 };
 
 export default function CardTable({ title, data, dbName }: Props) {
-  function createAndDownloadFile(data: any) {
+  async function createAndDownloadFile(data: any) {
+    const XLSX = await import('xlsx');
     const dataToDownload = data.map((dato: any) => ({
       id: dato.id,
       estado: dato.is_active ? 'Activo' : 'Inactivo',

--- a/src/modules/company/features/users/actions.server.ts
+++ b/src/modules/company/features/users/actions.server.ts
@@ -129,16 +129,9 @@ export const fetchSharedUsersByCompany = async (companyId: string) => {
             share_company_users: { include: { profile: true } },
             city_rel: { select: { name: true, id: true } },
             province_rel: { select: { name: true, id: true } },
-            employees: {
-              include: {
-                city_rel: { select: { name: true } },
-                province_rel: { select: { name: true } },
-                workflow_diagram_rel: { select: { name: true } },
-                hierarchy_rel: { select: { name: true } },
-                birthplace_rel: { select: { name: true } },
-                contractor_employee: { include: { contractor: true } },
-              },
-            },
+            // NOTA: se removió el include de `employees` (6 JOINs por empleado).
+            // Ningún consumidor de `sharedUsers` accede a company.employees y traía
+            // cientos de KB en cada cambio de empresa activa.
           },
         },
       },

--- a/src/modules/employees/features/diagrams/components/DiagramEmployeeView.tsx
+++ b/src/modules/employees/features/diagrams/components/DiagramEmployeeView.tsx
@@ -18,7 +18,6 @@ import { Button } from '@/shared/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@/shared/components/ui/command';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormMessage } from '@/shared/components/ui/form';
 
-import * as XLSX from 'xlsx';
 import InfoComponent from '@/shared/components/common/InfoComponent';
 
 type Checked = DropdownMenuCheckboxItemProps['checked'];
@@ -112,7 +111,8 @@ function DiagramEmployeeView({
 
   /*---------------------INICIO DESCARGA DE ARCHIVO ---------------------------*/
 
-  function createAndDownloadFile(data: any) {
+  async function createAndDownloadFile(data: any) {
+    const XLSX = await import('xlsx');
     const mes = generarDiasEntreFechas({ fechaInicio, fechaFin });
     // const dataToDownload = mes.map((dato: any) => ({
     //   Empleado: '',

--- a/src/modules/employees/features/list/actions.server.ts
+++ b/src/modules/employees/features/list/actions.server.ts
@@ -15,36 +15,41 @@ import {
 
 export const fetchAllEmployeesWithRelations = async () => {
   const { companyId } = await getActionContext();
-  const user = await fetchCurrentUser();
   if (!companyId) return [];
 
-  // Update user metadata via supabase auth admin
-  const supabase = await supabaseServer();
-  supabase.auth.admin.updateUserById(user?.id || '', {
-    app_metadata: {
-      company: companyId,
-    },
-  });
-
   try {
-    const data = await prisma.employees.findMany({
-      where: { company_id: companyId },
-      include: {
-        guild_rel: true,
-        covenants_rel: true,
-        category_rel: true,
-        city_rel: true,
-        province_rel: true,
-        workflow_diagram_rel: true,
-        hierarchy_rel: true,
-        birthplace_rel: true,
-        contractor_employee: {
-          include: { contractor: true },
+    // La query principal (lo más caro) arranca en paralelo con auth y el cliente
+    // de Supabase, en vez de esperarlos en cascada.
+    const [user, supabase, data] = await Promise.all([
+      fetchCurrentUser(),
+      supabaseServer(),
+      prisma.employees.findMany({
+        where: { company_id: companyId },
+        include: {
+          guild_rel: true,
+          covenants_rel: true,
+          category_rel: true,
+          city_rel: true,
+          province_rel: true,
+          workflow_diagram_rel: true,
+          hierarchy_rel: true,
+          birthplace_rel: true,
+          contractor_employee: {
+            include: { contractor: true },
+          },
         },
+        orderBy: { lastname: 'asc' },
+      }),
+    ]);
+
+    // Update user metadata via supabase auth admin (fire-and-forget, no bloquea)
+    supabase.auth.admin.updateUserById(user?.id || '', {
+      app_metadata: {
+        company: companyId,
       },
-      orderBy: { lastname: 'asc' },
     });
-    return (data ?? []);
+
+    return data ?? [];
   } catch (error) {
     console.error('Error fetching employees:', error);
     return [];

--- a/src/modules/forms/features/custom-forms/components/CreatedForm.tsx
+++ b/src/modules/forms/features/custom-forms/components/CreatedForm.tsx
@@ -24,7 +24,6 @@ import { types } from '@/shared/types/types';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import cookie from 'js-cookie';
-import jsPDF from 'jspdf';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import DisplayCreatedForms from './DisplayCreatedForms';
 import FormCard from './FormCard';
@@ -192,7 +191,8 @@ function CreatedForm() {
     }
   }, [companyInfo]);
 
-  const generarPDF = (formItem: any, printEmpty: boolean) => {
+  const generarPDF = async (formItem: any, printEmpty: boolean) => {
+    const { default: jsPDF } = await import('jspdf'); // Carga diferida (~200KB)
     const doc = new jsPDF(); // Crear una nueva instancia de jsPDF
     const pageHeight = doc.internal.pageSize.height; // Obtener la altura de la página
     const pageWidth = doc.internal.pageSize.width; // Obtener el ancho de la página

--- a/src/modules/forms/features/custom-forms/components/FormCard.tsx
+++ b/src/modules/forms/features/custom-forms/components/FormCard.tsx
@@ -2,8 +2,11 @@ import { Button } from '@/shared/components/ui/button';
 import { Card, CardDescription, CardHeader } from '@/shared/components/ui/card';
 import { Drawer, DrawerClose, DrawerContent, DrawerFooter, DrawerTrigger } from '@/shared/components/ui/drawer';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { FormUseChart } from './FormUseChart';
+import dynamic from 'next/dynamic';
 import { SubmitCustomForm } from './SubmitCustomForm';
+
+// Carga diferida: recharts (~45KB) sale del bundle inicial.
+const FormUseChart = dynamic(() => import('./FormUseChart').then((m) => m.FormUseChart));
 
 function FormCard({
   form,

--- a/src/modules/hse/features/documents/components/DocumentDetail.tsx
+++ b/src/modules/hse/features/documents/components/DocumentDetail.tsx
@@ -37,7 +37,6 @@ import { useRouter } from 'next/navigation';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import * as XLSX from 'xlsx';
 import Cookies from 'js-cookie';
 // interface ExtendedDocument extends Document {
 //   documentTitle: string;
@@ -638,8 +637,9 @@ export default function DocumentDetail({ id }: DocumentDetailProps) {
     }
   };
 
-  const exportToExcel = () => {
+  const exportToExcel = async () => {
     try {
+      const XLSX = await import('xlsx');
       if (!document || !employeesWithDocuments.length) {
         toast.info('No hay empleados para exportar');
         return;

--- a/src/shared/components/common/BtnXlsDownload.tsx
+++ b/src/shared/components/common/BtnXlsDownload.tsx
@@ -1,9 +1,10 @@
 import { FileDown } from 'lucide-react';
-import * as XLSX from 'xlsx';
 import { Button } from '@/shared/components/ui/button';
 
 function BtnXlsDownload({ dataToDownload, fn, nameFile }: { dataToDownload: any; nameFile: string; fn: any }) {
-  function createAndDownloadFile(data: any) {
+  async function createAndDownloadFile(data: any) {
+    // Carga diferida de xlsx (~300KB): solo cuando el usuario descarga.
+    const XLSX = await import('xlsx');
     // Obtener todas las propiedades únicas
     const allKeys = Array.from(new Set(data.flatMap((item: any) => Object.keys(item))));
 


### PR DESCRIPTION
- next.config: optimizePackageImports (lucide, recharts, date-fns, etc.)
- lazy-load de xlsx (~300KB), jsPDF (~200KB) y recharts (~45KB) vía await import()/next/dynamic, fuera del bundle inicial
- fetchSharedUsersByCompany: remover include de employees (6 JOINs/empleado) innecesario en cada cambio de empresa
- fetchAllEmployeesWithRelations: early-exit + Promise.all para evitar cascada auth/cliente/query