### PR TITLE
fix(ayuda): tsk-299 alinear categorías de tickets con el sidebar

### DIFF
--- a/src/modules/ayuda/components/TicketForm.tsx
+++ b/src/modules/ayuda/components/TicketForm.tsx
@@ -28,25 +28,15 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
-import { CATEGORIES, type CategorySlug } from '../constants/categories';
+import { CATEGORIES, CATEGORY_SLUGS, type CategorySlug } from '../constants/categories';
 import { useCreateTicket } from '../hooks/useCreateTicket';
 import { useUploadAttachment } from '../hooks/useUploadAttachment';
 import { TicketAttachmentInput } from './TicketAttachmentInput';
 import { TicketPrioritySelect } from './TicketPrioritySelect';
 
 const formSchema = z.object({
-  category: z.enum([
-    'dashboard',
-    'empresa',
-    'empleados',
-    'equipos',
-    'comercial',
-    'documentacion',
-    'operaciones',
-    'mantenimiento',
-    'formularios',
-    'otro',
-  ]),
+  // Derivado de CATEGORIES para que el form siga al sidebar sin desincronizarse.
+  category: z.enum(CATEGORY_SLUGS),
   priority: z.enum(['low', 'medium', 'high', 'critical']),
   title: z.string().trim().min(3, 'Mínimo 3 caracteres').max(200, 'Máximo 200 caracteres'),
   description: z

--- a/src/modules/ayuda/constants/categories.ts
+++ b/src/modules/ayuda/constants/categories.ts
@@ -1,27 +1,40 @@
 import {
   Building2,
+  Calculator,
   Calendar,
   ClipboardList,
   FileText,
-  HandHelping,
+  GraduationCap,
   LayoutDashboard,
   MoreHorizontal,
+  Settings,
+  ShoppingCart,
   Truck,
   Users,
+  Wallet,
+  Warehouse,
   Wrench,
   type LucideIcon,
 } from 'lucide-react';
 
+// Las categorías reflejan los módulos del sidebar de CodeControl
+// (ver src/shared/components/layout/SideBarContainer.tsx), para que el usuario
+// reporte el ticket sobre el módulo correcto. "Otro" es el catch-all.
 export type CategorySlug =
   | 'dashboard'
   | 'empresa'
   | 'empleados'
   | 'equipos'
-  | 'comercial'
   | 'documentacion'
-  | 'operaciones'
+  | 'almacenes'
+  | 'compras'
+  | 'tesoreria'
   | 'mantenimiento'
   | 'formularios'
+  | 'operaciones'
+  | 'hse'
+  | 'costos'
+  | 'configuracion'
   | 'otro';
 
 export interface CategoryDef {
@@ -35,13 +48,20 @@ export const CATEGORIES: CategoryDef[] = [
   { slug: 'empresa', label: 'Empresa', icon: Building2 },
   { slug: 'empleados', label: 'Empleados', icon: Users },
   { slug: 'equipos', label: 'Equipos', icon: Truck },
-  { slug: 'comercial', label: 'Comercial', icon: HandHelping },
   { slug: 'documentacion', label: 'Documentación', icon: FileText },
-  { slug: 'operaciones', label: 'Operaciones', icon: Calendar },
+  { slug: 'almacenes', label: 'Almacenes', icon: Warehouse },
+  { slug: 'compras', label: 'Compras', icon: ShoppingCart },
+  { slug: 'tesoreria', label: 'Tesorería', icon: Wallet },
   { slug: 'mantenimiento', label: 'Mantenimiento', icon: Wrench },
   { slug: 'formularios', label: 'Formularios', icon: ClipboardList },
+  { slug: 'operaciones', label: 'Operaciones', icon: Calendar },
+  { slug: 'hse', label: 'HSE', icon: GraduationCap },
+  { slug: 'costos', label: 'Gestión de Costos', icon: Calculator },
+  { slug: 'configuracion', label: 'Configuración', icon: Settings },
   { slug: 'otro', label: 'Otro', icon: MoreHorizontal },
 ];
+
+export const CATEGORY_SLUGS = CATEGORIES.map((c) => c.slug) as [CategorySlug, ...CategorySlug[]];
 
 export const CATEGORY_BY_SLUG: Record<CategorySlug, CategoryDef> = Object.fromEntries(
   CATEGORIES.map((c) => [c.slug, c])


### PR DESCRIPTION
Reincorpora el ajuste de categorías que quedó fuera del merge del PR #390 por un race en el push.

Las categorías del formulario de tickets reflejan ahora los módulos reales del sidebar (`SideBarContainer`): se quita "Comercial" y se agregan Almacenes, Compras, Tesorería, HSE, Gestión de Costos y Configuración. El enum de validación se deriva de `CATEGORIES` para evitar futuras desincronizaciones.