### PR TITLE
feat(compras): tsk-9 lectura de facturas de compra con AI + config de proveedores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,25 @@ RESEND_SUPABASE_API_KEY=
 # TASKAPP (Centro de Ayuda — backend de tickets en apitaskapp.codecontrol.com.ar)
 TASKAPP_BASE_URL=
 TASKAPP_PROJECT_API_KEY=
+
+# IA / Lectura de facturas (módulo Compras)
+# A partir de ahora el proveedor de IA y sus API keys se configuran desde la UI
+# (Configuración → IA / Proveedores, solo admin de plataforma) y se guardan
+# CIFRADAS en la tabla `ai_provider_config`. Las envs de abajo quedan como
+# fallback/compatibilidad.
+
+# ENCRYPTION_KEY (REQUERIDA): clave usada para cifrar/descifrar las API keys de
+# los proveedores de IA guardadas en la DB (AES-256-GCM; se deriva con SHA-256).
+# Debe ser un string secreto y estable: si cambia, las keys ya guardadas dejan
+# de poder descifrarse. No la compartas ni la subas al repo.
+ENCRYPTION_KEY=
+
+# GEMINI (FALLBACK opcional). Si NO hay un proveedor activo configurado en la UI,
+# la extracción usa estas envs como respaldo.
+# GEMINI_API_KEY: API key de Google AI Studio (Gemini).
+# GEMINI_MODEL: opcional; default 'gemini-2.5-flash' si se deja vacío.
+GEMINI_API_KEY=
+GEMINI_MODEL=
+
+# OPENAI (opcional): NO se configura por env. Si querés usar OpenAI/ChatGPT,
+# cargá su API key y modelo desde la UI (Configuración → IA / Proveedores).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3050,3 +3050,17 @@ model support_ticket_views {
   @@id([user_id, taskapp_ticket_id])
   @@index([user_id], map: "idx_support_ticket_views_user_id")
 }
+
+// ============================================================
+// IA — Configuración global de proveedores de extracción
+// ============================================================
+
+model ai_provider_config {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  provider   String   @unique // 'gemini' | 'openai'
+  api_key    String? // cifrado (iv:tag:cipher en base64); null si no configurada
+  model      String? // ej 'gemini-2.5-flash' | 'gpt-4o-mini'
+  is_active  Boolean  @default(false) // exactamente UNA fila true = proveedor en uso
+  created_at DateTime @default(now()) @db.Timestamptz
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz
+}

--- a/src/app/dashboard/purchasing/invoices/new/page.tsx
+++ b/src/app/dashboard/purchasing/invoices/new/page.tsx
@@ -14,7 +14,7 @@ export default async function NewInvoicePage() {
     <div className="w-full">
       <h1 className="text-2xl font-bold mb-6">Nueva factura de compra</h1>
       <PurchaseInvoiceForm
-        suppliers={suppliers as any}
+        suppliers={suppliers}
         products={products.map((p) => ({ ...p, cost_price: Number(p.cost_price), vat_rate: Number(p.vat_rate) }))}
         perceptionTypes={perceptionTypes.filter((t) => t.is_active)}
       />

--- a/src/modules/purchasing/features/invoices/create/actions.server.ts
+++ b/src/modules/purchasing/features/invoices/create/actions.server.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { extractInvoiceFromFile } from '@/modules/purchasing/shared/invoice-extraction/extract-invoice';
+import type { ExtractedInvoice } from '@/modules/purchasing/shared/invoice-extraction/types';
+import {
+  PURCHASE_INVOICE_ATTACHMENT_ALLOWED_MIME,
+  PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES,
+} from '@/modules/purchasing/shared/validators';
+
+/**
+ * NOTA SOBRE EL RUNTIME:
+ * Esta server action usa `Buffer` y llama a Gemini vía `fetch` con un archivo
+ * en base64. Las server actions corren en Node.js por defecto, así que no hay
+ * que setear `runtime` acá. La PÁGINA que consume esta action
+ * (src/app/dashboard/purchasing/invoices/new/page.tsx) NO debe forzar
+ * `export const runtime = 'edge'` — debe quedar en el runtime nodejs por
+ * defecto para que la extracción funcione.
+ */
+
+type ExtractInvoiceResult =
+  | { ok: true; data: ExtractedInvoice }
+  | { ok: false; error: string };
+
+/**
+ * Recibe el archivo de una factura de compra (PDF o imagen) desde el cliente,
+ * lo valida (MIME + tamaño), lo convierte a base64 y lo manda a la capa de
+ * extracción AI. Devuelve los datos extraídos para PRE-LLENAR el formulario.
+ *
+ * NO sube el archivo a storage ni guarda nada: solo extrae. La subida y el
+ * guardado de la factura se manejan en sus propios lotes/acciones.
+ *
+ * @param formData FormData con el archivo bajo la key `file`.
+ */
+export async function extractInvoiceDataFromFile(
+  formData: FormData
+): Promise<ExtractInvoiceResult> {
+  const raw = formData.get('file');
+
+  if (!(raw instanceof File)) {
+    return { ok: false, error: 'No se recibió ningún archivo válido.' };
+  }
+
+  if (raw.size === 0) {
+    return { ok: false, error: 'El archivo está vacío.' };
+  }
+
+  if (raw.size > PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES) {
+    return { ok: false, error: 'El archivo supera los 10 MB.' };
+  }
+
+  if (
+    !(PURCHASE_INVOICE_ATTACHMENT_ALLOWED_MIME as readonly string[]).includes(raw.type)
+  ) {
+    return {
+      ok: false,
+      error: 'Formato no permitido. Subí una imagen (JPG/PNG) o un PDF.',
+    };
+  }
+
+  try {
+    const base64 = Buffer.from(await raw.arrayBuffer()).toString('base64');
+    const data = await extractInvoiceFromFile({ base64, mimeType: raw.type });
+    return { ok: true, data };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : 'No se pudieron leer los datos de la factura.',
+    };
+  }
+}

--- a/src/modules/purchasing/features/invoices/create/components/InvoiceAIUpload.tsx
+++ b/src/modules/purchasing/features/invoices/create/components/InvoiceAIUpload.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useEffect, useId, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Sparkles, UploadCloud, Loader2, FileText } from 'lucide-react';
+import { Card, CardContent } from '@/shared/components/ui/card';
+import { cn } from '@/shared/lib/utils';
+import {
+  PURCHASE_INVOICE_ATTACHMENT_ALLOWED_MIME,
+  PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES,
+} from '@/modules/purchasing/shared/validators';
+import { extractInvoiceDataFromFile } from '@/modules/purchasing/features/invoices/create/actions.server';
+import {
+  mapExtractedToForm,
+  type MapExtractedToFormResult,
+  type SupplierForMatch,
+} from '@/modules/purchasing/shared/invoice-extraction/map-to-form';
+
+/** Payload que recibe el form cuando la extracción terminó OK. */
+export interface InvoiceExtractionResult extends MapExtractedToFormResult {
+  /** Archivo original, para reusarlo como adjunto al guardar. */
+  file: File;
+}
+
+interface Props {
+  /** Proveedores ya pre-fetcheados por la page, para matchear el CUIT. */
+  suppliers: SupplierForMatch[];
+  /** Callback con los datos extraídos + mapeados al form. */
+  onExtracted: (result: InvoiceExtractionResult) => void;
+  /** Deshabilita la zona (ej. mientras se guarda la factura). */
+  disabled?: boolean;
+}
+
+const ACCEPT = '.pdf,.jpg,.jpeg,.png';
+
+/**
+ * Mensajes de etapa que se rotan mientras la AI procesa el archivo.
+ * El progreso real es indeterminado (no conocemos el % exacto del lado del
+ * servidor), por eso no inventamos un porcentaje: rotamos texto + spinner.
+ */
+const EXTRACTION_STAGES = [
+  'Subiendo archivo…',
+  'Analizando la factura con IA…',
+  'Extrayendo importes y datos…',
+  'Casi listo…',
+] as const;
+
+/** Cada cuántos ms rota el mensaje de etapa. */
+const STAGE_ROTATION_MS = 2500;
+
+export default function InvoiceAIUpload({ suppliers, onExtracted, disabled }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
+  const [loading, setLoading] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const [lastFileName, setLastFileName] = useState<string | null>(null);
+  const [stageIndex, setStageIndex] = useState(0);
+
+  // Rota el mensaje de etapa mientras `loading`, y lo limpia al terminar.
+  useEffect(() => {
+    if (!loading) {
+      setStageIndex(0);
+      return;
+    }
+    const id = setInterval(() => {
+      // Avanza hasta la última etapa y se queda ahí (no vuelve a empezar).
+      setStageIndex((prev) => Math.min(prev + 1, EXTRACTION_STAGES.length - 1));
+    }, STAGE_ROTATION_MS);
+    return () => clearInterval(id);
+  }, [loading]);
+
+  const validateFile = (file: File): string | null => {
+    if (!(PURCHASE_INVOICE_ATTACHMENT_ALLOWED_MIME as readonly string[]).includes(file.type)) {
+      return 'Formato no permitido. Subí una imagen (JPG/PNG) o un PDF.';
+    }
+    if (file.size === 0) return 'El archivo está vacío.';
+    if (file.size > PURCHASE_INVOICE_ATTACHMENT_MAX_BYTES) {
+      return 'El archivo supera los 10 MB.';
+    }
+    return null;
+  };
+
+  const processFile = async (file: File) => {
+    const error = validateFile(file);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setLoading(true);
+    setLastFileName(file.name);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await extractInvoiceDataFromFile(fd);
+
+      if (!res.ok) {
+        toast.error(res.error);
+        return;
+      }
+
+      const mapped = mapExtractedToForm(res.data, suppliers);
+      onExtracted({ ...mapped, file });
+    } catch {
+      toast.error('No se pudieron leer los datos de la factura.');
+    } finally {
+      setLoading(false);
+      // Permite re-subir el mismo archivo.
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void processFile(file);
+  };
+
+  const openPicker = () => {
+    if (loading || disabled) return;
+    inputRef.current?.click();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openPicker();
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    if (loading || disabled) return;
+    const file = e.dataTransfer.files?.[0];
+    if (file) void processFile(file);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (loading || disabled) return;
+    if (!dragActive) setDragActive(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+  };
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardContent className="p-4">
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={ACCEPT}
+          hidden
+          onChange={handleInputChange}
+          disabled={loading || disabled}
+        />
+
+        <div
+          role="button"
+          tabIndex={loading || disabled ? -1 : 0}
+          aria-disabled={loading || disabled}
+          aria-label="Cargar datos desde una factura (PDF o imagen)"
+          onClick={openPicker}
+          onKeyDown={handleKeyDown}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          className={cn(
+            'flex flex-col items-center justify-center gap-3 rounded-md border-2 border-dashed px-4 py-6 text-center transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            dragActive ? 'border-primary bg-primary/10' : 'border-primary/30',
+            loading || disabled ? 'cursor-not-allowed opacity-80' : 'cursor-pointer hover:border-primary hover:bg-primary/10'
+          )}
+        >
+          {loading ? (
+            <>
+              <Loader2 className="size-7 animate-spin text-primary" />
+              <div className="w-full max-w-xs space-y-2">
+                <p className="text-sm font-medium text-primary">{EXTRACTION_STAGES[stageIndex]}</p>
+                {lastFileName && (
+                  <p className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+                    <FileText className="size-3.5 shrink-0" />
+                    <span className="truncate">{lastFileName}</span>
+                  </p>
+                )}
+                {/* Barra indeterminada: un segmento que se desplaza, sin % falso. */}
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-primary/20">
+                  <div className="h-full w-1/3 animate-indeterminate-progress rounded-full bg-primary" />
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex size-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Sparkles className="size-5" />
+              </div>
+              <div className="space-y-1">
+                <p className="flex items-center justify-center gap-1.5 text-sm font-semibold text-foreground">
+                  <UploadCloud className="size-4 text-primary" /> Cargar desde factura
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Arrastrá un PDF o imagen, o hacé clic para elegir. La AI completa el formulario
+                  y vos revisás antes de guardar.
+                </p>
+                <p className="text-[11px] text-muted-foreground/80">JPG, PNG o PDF. Máx. 10 MB.</p>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Región para lectores de pantalla: anuncia la etapa actual. */}
+        <div aria-live="polite" className="sr-only">
+          {loading ? EXTRACTION_STAGES[stageIndex] : ''}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
+++ b/src/modules/purchasing/features/invoices/create/components/PurchaseInvoiceForm.tsx
@@ -21,6 +21,7 @@ import {
   getOrdersForInvoicing,
   getPurchaseOrderLinesForInvoicingBulk,
 } from '@/modules/purchasing/features/purchase-orders/list/actions.server';
+import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/components/ui/card';
@@ -32,11 +33,42 @@ import { SearchableSelect } from '@/shared/components/ui/searchable-select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/table';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
-import { Plus, Trash2, LinkIcon, Paperclip, X, PackagePlus } from 'lucide-react';
+import { Plus, Trash2, LinkIcon, Paperclip, X, PackagePlus, AlertTriangle, CheckCircle2 } from 'lucide-react';
 import { useMemo, useState, useEffect, useRef } from 'react';
 import QuickCreateProductModal from './_QuickCreateProductModal';
+import InvoiceAIUpload, { type InvoiceExtractionResult } from './InvoiceAIUpload';
+import QuickCreateSupplierModal, { type QuickCreatedSupplier } from './_QuickCreateSupplierModal';
 
 type FormValues = z.infer<typeof purchaseInvoiceSchema>;
+
+/** Formatea 11 dígitos a XX-XXXXXXXX-X para mostrar; si no, devuelve tal cual. */
+function formatCuitDisplay(cuit: string | null): string {
+  if (!cuit) return '';
+  const clean = cuit.replace(/\D/g, '');
+  if (clean.length === 11) {
+    return `${clean.slice(0, 2)}-${clean.slice(2, 10)}-${clean.slice(10)}`;
+  }
+  return cuit;
+}
+
+/** Badge de estado de extracción AI para un campo. */
+function FieldStatusBadge({ status }: { status: 'extracted' | 'review' | null }) {
+  if (status === 'extracted') {
+    return (
+      <Badge variant="success" className="ml-2 gap-1 px-1.5 py-0 text-[10px]">
+        <CheckCircle2 className="size-3" /> Extraído
+      </Badge>
+    );
+  }
+  if (status === 'review') {
+    return (
+      <Badge variant="yellow" className="ml-2 gap-1 px-1.5 py-0 text-[10px]">
+        <AlertTriangle className="size-3" /> Revisar
+      </Badge>
+    );
+  }
+  return null;
+}
 
 type LineField = {
   product_id?: string;
@@ -79,13 +111,13 @@ export type InvoiceInitialData = {
 };
 
 interface Props {
-  suppliers: { id: string; code: string; business_name: string }[];
+  suppliers: { id: string; code: string; business_name: string; tax_id?: string | null }[];
   products: { id: string; code: string; name: string; cost_price: number; vat_rate: number }[];
   perceptionTypes: PerceptionTypeOpt[];
   initialData?: InvoiceInitialData;
 }
 
-export default function PurchaseInvoiceForm({ suppliers, products: initialProducts, perceptionTypes, initialData }: Props) {
+export default function PurchaseInvoiceForm({ suppliers: initialSuppliers, products: initialProducts, perceptionTypes, initialData }: Props) {
   const router = useRouter();
   const isEditMode = !!initialData;
   const [availableOrders, setAvailableOrders] = useState<any[]>([]);
@@ -93,6 +125,21 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [localProducts, setLocalProducts] = useState(initialProducts);
   const [quickProductOpen, setQuickProductOpen] = useState(false);
+
+  // Proveedores en estado local: la extracción AI puede dar de alta uno nuevo
+  // y necesitamos que aparezca en el dropdown sin recargar.
+  const [suppliers, setSuppliers] = useState(initialSuppliers);
+
+  // --- Extracción AI: estado para badges y mini-modal de proveedor ----------
+  const [extractedFields, setExtractedFields] = useState<Set<string>>(new Set());
+  const [lowConfidenceFields, setLowConfidenceFields] = useState<Set<string>>(new Set());
+  const [quickSupplierOpen, setQuickSupplierOpen] = useState(false);
+  const [pendingSupplierData, setPendingSupplierData] = useState<{
+    razonSocial: string | null;
+    cuit: string | null;
+  }>({ razonSocial: null, cuit: null });
+  // El usuario eligió "Elegir manualmente": ocultar el aviso de crear proveedor.
+  const [supplierAlertDismissed, setSupplierAlertDismissed] = useState(false);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(purchaseInvoiceSchema),
@@ -380,6 +427,87 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
     setAttachment(file);
   };
 
+  // --- Extracción AI: aplicar lo extraído al formulario --------------------
+  const handleExtracted = (result: InvoiceExtractionResult) => {
+    const { values, supplierMatch, lowConfidenceFields: lowConf, file } = result;
+    const filled = new Set<string>();
+
+    // Pre-llenar cada clave resuelta con confianza.
+    (Object.keys(values) as (keyof FormValues)[]).forEach((key) => {
+      if (key === 'lines') return; // se trata aparte con replace()
+      const value = values[key];
+      if (value === undefined) return;
+      form.setValue(key, value as any, { shouldValidate: true, shouldDirty: true });
+      filled.add(key as string);
+    });
+
+    // Líneas: reemplazar solo si la AI extrajo al menos una.
+    if (values.lines && values.lines.length > 0) {
+      replace(
+        values.lines.map((l) => ({
+          product_id: '',
+          description: l.description,
+          quantity: l.quantity,
+          unit_cost: l.unit_cost,
+          vat_rate: l.vat_rate,
+          discount_type: null,
+          discount_value: null,
+        }))
+      );
+      filled.add('lines');
+    }
+
+    setExtractedFields(filled);
+    setLowConfidenceFields(new Set(lowConf));
+
+    // El archivo leído queda como adjunto (se sube al guardar).
+    setAttachment(file);
+    setAttachmentError(null);
+
+    // Si no matcheó proveedor, ofrecer crearlo con datos pre-cargados.
+    if (!supplierMatch.matched) {
+      setPendingSupplierData({
+        razonSocial: supplierMatch.razonSocial,
+        cuit: supplierMatch.cuit,
+      });
+      setSupplierAlertDismissed(false);
+    } else {
+      setPendingSupplierData({ razonSocial: null, cuit: null });
+    }
+
+    toast.success('Datos cargados — revisá los campos antes de guardar');
+
+    // Mover el foco al primer campo de baja confianza para que el usuario lo corrija.
+    if (lowConf.length > 0) {
+      const first = lowConf.find((f) => f !== 'supplier_id' && f !== 'lines');
+      if (first) {
+        setTimeout(() => {
+          try {
+            form.setFocus(first as any);
+          } catch {
+            /* el campo puede no ser focusable (ej. selects custom) */
+          }
+        }, 50);
+      }
+    }
+  };
+
+  const handleSupplierCreated = (supplier: QuickCreatedSupplier) => {
+    setSuppliers((prev) => [
+      ...prev,
+      { id: supplier.id, code: supplier.code, business_name: supplier.business_name, tax_id: supplier.tax_id },
+    ]);
+    form.setValue('supplier_id', supplier.id, { shouldValidate: true, shouldDirty: true });
+    // Ya no es un campo de baja confianza, y quedó "extraído"/resuelto.
+    setLowConfidenceFields((prev) => {
+      const next = new Set(prev);
+      next.delete('supplier_id');
+      return next;
+    });
+    setExtractedFields((prev) => new Set(prev).add('supplier_id'));
+    setPendingSupplierData({ razonSocial: null, cuit: null });
+  };
+
   const onSubmit = async (values: FormValues) => {
     const sanitizedLines = (values.lines as LineField[]).map((l) => ({
       product_id: l.product_id,
@@ -470,14 +598,33 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
     });
   };
 
+  // Estado de un campo para el badge: revisar > extraído > nada.
+  const fieldStatus = (name: string): 'extracted' | 'review' | null => {
+    if (lowConfidenceFields.has(name)) return 'review';
+    if (extractedFields.has(name)) return 'extracted';
+    return null;
+  };
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {!isEditMode && (
+          <InvoiceAIUpload
+            suppliers={suppliers.map((s) => ({
+              id: s.id,
+              business_name: s.business_name,
+              tax_id: s.tax_id ?? null,
+            }))}
+            onExtracted={handleExtracted}
+            disabled={form.formState.isSubmitting}
+          />
+        )}
         <Card>
           <CardHeader><CardTitle>Datos del comprobante</CardTitle></CardHeader>
           <CardContent className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <FormField control={form.control} name="supplier_id" render={({ field }) => (
-              <FormItem className="lg:col-span-2"><FormLabel>Proveedor *</FormLabel>
+              <FormItem className="lg:col-span-2">
+                <FormLabel className="flex items-center">Proveedor *<FieldStatusBadge status={fieldStatus('supplier_id')} /></FormLabel>
                 {isEditMode ? (
                   <Input
                     value={suppliers.find((s) => s.id === field.value)?.business_name || ''}
@@ -493,10 +640,50 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
                     searchPlaceholder="Buscar proveedor..."
                   />
                 )}
+                {!isEditMode &&
+                  !supplierAlertDismissed &&
+                  (pendingSupplierData.cuit || pendingSupplierData.razonSocial) &&
+                  !field.value && (
+                    <Alert className="mt-2 border-yellow-500/50 text-yellow-700 dark:text-yellow-500 [&>svg]:text-yellow-600">
+                      <AlertTriangle className="size-4" />
+                      <AlertTitle>Proveedor no encontrado</AlertTitle>
+                      <AlertDescription className="text-yellow-700/90 dark:text-yellow-500/90">
+                        <p>
+                          No encontramos un proveedor con CUIT{' '}
+                          <span className="font-mono font-medium">
+                            {formatCuitDisplay(pendingSupplierData.cuit) || '(sin CUIT)'}
+                          </span>
+                          .
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="gap-1"
+                            onClick={() => setQuickSupplierOpen(true)}
+                          >
+                            <Plus className="size-4" />
+                            Crear proveedor
+                            {pendingSupplierData.razonSocial
+                              ? ` "${pendingSupplierData.razonSocial}"`
+                              : ''}
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setSupplierAlertDismissed(true)}
+                          >
+                            Elegir manualmente
+                          </Button>
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
                 <FormMessage /></FormItem>
             )} />
             <FormField control={form.control} name="voucher_type" render={({ field }) => (
-              <FormItem><FormLabel>Tipo *</FormLabel>
+              <FormItem><FormLabel className="flex items-center">Tipo *<FieldStatusBadge status={fieldStatus('voucher_type')} /></FormLabel>
                 <Select onValueChange={field.onChange} value={field.value}>
                   <FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl>
                   <SelectContent>{Object.entries(VOUCHER_TYPE_LABELS).map(([v, l]) => <SelectItem key={v} value={v}>{l}</SelectItem>)}</SelectContent>
@@ -526,19 +713,19 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
               )} />
             )}
             <FormField control={form.control} name="point_of_sale" render={({ field }) => (
-              <FormItem><FormLabel>Pto. venta *</FormLabel><FormControl><Input placeholder="00001" maxLength={5} {...field} onBlur={(e) => { field.onBlur(); field.onChange(e.target.value.padStart(5, '0')); }} /></FormControl><FormMessage /></FormItem>
+              <FormItem><FormLabel className="flex items-center">Pto. venta *<FieldStatusBadge status={fieldStatus('point_of_sale')} /></FormLabel><FormControl><Input placeholder="00001" maxLength={5} {...field} onBlur={(e) => { field.onBlur(); field.onChange(e.target.value.padStart(5, '0')); }} /></FormControl><FormMessage /></FormItem>
             )} />
             <FormField control={form.control} name="number" render={({ field }) => (
-              <FormItem><FormLabel>Número *</FormLabel><FormControl><Input placeholder="00000001" {...field} /></FormControl><FormMessage /></FormItem>
+              <FormItem><FormLabel className="flex items-center">Número *<FieldStatusBadge status={fieldStatus('number')} /></FormLabel><FormControl><Input placeholder="00000001" {...field} /></FormControl><FormMessage /></FormItem>
             )} />
             <FormField control={form.control} name="issue_date" render={({ field }) => (
-              <FormItem><FormLabel>Fecha emisión *</FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormMessage /></FormItem>
+              <FormItem><FormLabel className="flex items-center">Fecha emisión *<FieldStatusBadge status={fieldStatus('issue_date')} /></FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormMessage /></FormItem>
             )} />
             <FormField control={form.control} name="due_date" render={({ field }) => (
-              <FormItem><FormLabel>Vencimiento</FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormMessage /></FormItem>
+              <FormItem><FormLabel className="flex items-center">Vencimiento<FieldStatusBadge status={fieldStatus('due_date')} /></FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormMessage /></FormItem>
             )} />
             <FormField control={form.control} name="cae" render={({ field }) => (
-              <FormItem><FormLabel>CAE</FormLabel><FormControl><Input placeholder="CAE" {...field} /></FormControl><FormMessage /></FormItem>
+              <FormItem><FormLabel className="flex items-center">CAE<FieldStatusBadge status={fieldStatus('cae')} /></FormLabel><FormControl><Input placeholder="CAE" {...field} /></FormControl><FormMessage /></FormItem>
             )} />
           </CardContent>
         </Card>
@@ -574,7 +761,7 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Líneas</CardTitle>
+            <CardTitle className="flex items-center">Líneas<FieldStatusBadge status={fieldStatus('lines')} /></CardTitle>
             <div className="flex gap-2">
               <Button type="button" variant="outline" size="sm" onClick={() => append({ product_id: '', description: '', quantity: 1, unit_cost: 0, vat_rate: 21, discount_type: null, discount_value: null })}>
                 <Plus className="size-4 mr-1" /> Agregar línea
@@ -930,6 +1117,14 @@ export default function PurchaseInvoiceForm({ suppliers, products: initialProduc
           </Button>
         </div>
       </form>
+
+      <QuickCreateSupplierModal
+        open={quickSupplierOpen}
+        onOpenChange={setQuickSupplierOpen}
+        initialBusinessName={pendingSupplierData.razonSocial}
+        initialCuit={pendingSupplierData.cuit}
+        onSupplierCreated={handleSupplierCreated}
+      />
 
       <QuickCreateProductModal
         open={quickProductOpen}

--- a/src/modules/purchasing/features/invoices/create/components/_QuickCreateSupplierModal.tsx
+++ b/src/modules/purchasing/features/invoices/create/components/_QuickCreateSupplierModal.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { createSupplier } from '@/modules/suppliers/features/list/actions.server';
+import { Button } from '@/shared/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { Input } from '@/shared/components/ui/input';
+import { Label } from '@/shared/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { toast } from 'sonner';
+
+const cuitRegex = /^\d{2}-?\d{8}-?\d{1}$/;
+
+const quickSupplierSchema = z.object({
+  business_name: z.string().min(1, 'La razón social es requerida').max(200),
+  tax_id: z.string().regex(cuitRegex, 'CUIT inválido (formato: XX-XXXXXXXX-X)'),
+  tax_condition: z.enum([
+    'RESPONSABLE_INSCRIPTO',
+    'MONOTRIBUTISTA',
+    'EXENTO',
+    'NO_RESPONSABLE',
+    'CONSUMIDOR_FINAL',
+  ]),
+});
+
+type TaxCondition = z.infer<typeof quickSupplierSchema>['tax_condition'];
+
+const TAX_CONDITION_LABELS: Record<TaxCondition, string> = {
+  RESPONSABLE_INSCRIPTO: 'Responsable Inscripto',
+  MONOTRIBUTISTA: 'Monotributista',
+  EXENTO: 'Exento',
+  NO_RESPONSABLE: 'No Responsable',
+  CONSUMIDOR_FINAL: 'Consumidor Final',
+};
+
+export interface QuickCreatedSupplier {
+  id: string;
+  code: string;
+  business_name: string;
+  tax_id: string | null;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Razón social pre-cargada desde la extracción AI. */
+  initialBusinessName?: string | null;
+  /** CUIT (solo dígitos) pre-cargado desde la extracción AI. */
+  initialCuit?: string | null;
+  onSupplierCreated: (supplier: QuickCreatedSupplier) => void;
+}
+
+/** Formatea 11 dígitos a XX-XXXXXXXX-X; si no, devuelve tal cual. */
+function formatCuit(digits: string): string {
+  const clean = digits.replace(/\D/g, '');
+  if (clean.length === 11) {
+    return `${clean.slice(0, 2)}-${clean.slice(2, 10)}-${clean.slice(10)}`;
+  }
+  return digits;
+}
+
+export default function QuickCreateSupplierModal({
+  open,
+  onOpenChange,
+  initialBusinessName,
+  initialCuit,
+  onSupplierCreated,
+}: Props) {
+  const [businessName, setBusinessName] = useState('');
+  const [taxId, setTaxId] = useState('');
+  const [taxCondition, setTaxCondition] = useState<TaxCondition>('RESPONSABLE_INSCRIPTO');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  // Pre-cargar con lo extraído cada vez que se abre el modal.
+  useEffect(() => {
+    if (open) {
+      setBusinessName(initialBusinessName?.trim() || '');
+      setTaxId(initialCuit ? formatCuit(initialCuit) : '');
+      setTaxCondition('RESPONSABLE_INSCRIPTO');
+      setErrors({});
+    }
+  }, [open, initialBusinessName, initialCuit]);
+
+  const handleSubmit = async () => {
+    setErrors({});
+    const parsed = quickSupplierSchema.safeParse({
+      business_name: businessName,
+      tax_id: taxId,
+      tax_condition: taxCondition,
+    });
+
+    if (!parsed.success) {
+      const fieldErrors: Record<string, string> = {};
+      for (const issue of parsed.error.issues) {
+        fieldErrors[issue.path[0] as string] = issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await createSupplier({
+        business_name: parsed.data.business_name,
+        tax_id: parsed.data.tax_id,
+        tax_condition: parsed.data.tax_condition,
+      });
+
+      if (result.error || !result.data) {
+        toast.error(result.error || 'Error al crear proveedor');
+        return;
+      }
+
+      toast.success(`Proveedor "${result.data.business_name}" creado`);
+      onSupplierCreated({
+        id: result.data.id,
+        code: result.data.code,
+        business_name: result.data.business_name,
+        tax_id: result.data.tax_id ?? null,
+      });
+      onOpenChange(false);
+    } catch {
+      toast.error('Error al crear proveedor');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Crear proveedor</DialogTitle>
+          <DialogDescription>
+            No encontramos un proveedor con este CUIT. Damos de alta los datos mínimos
+            (los pre-cargamos desde la factura). Podés completar el resto después desde
+            el módulo de proveedores.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="qs-name">Razón social *</Label>
+            <Input
+              id="qs-name"
+              value={businessName}
+              onChange={(e) => setBusinessName(e.target.value)}
+              placeholder="Ej: Distribuidora del Sur S.A."
+              autoFocus
+            />
+            {errors.business_name && (
+              <p className="text-xs text-destructive">{errors.business_name}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="qs-cuit">CUIT *</Label>
+            <Input
+              id="qs-cuit"
+              value={taxId}
+              onChange={(e) => setTaxId(e.target.value)}
+              placeholder="XX-XXXXXXXX-X"
+            />
+            {errors.tax_id && <p className="text-xs text-destructive">{errors.tax_id}</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Condición fiscal *</Label>
+            <Select value={taxCondition} onValueChange={(v) => setTaxCondition(v as TaxCondition)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TAX_CONDITION_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.tax_condition && (
+              <p className="text-xs text-destructive">{errors.tax_condition}</p>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Creando...' : 'Crear proveedor'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/purchasing/shared/invoice-extraction/ai-config.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/ai-config.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+
+import { prisma } from '@/shared/lib/prisma';
+import { decryptSecret } from '@/shared/lib/crypto';
+
+/** Proveedores de AI soportados para la extracción de facturas. */
+export type AiProvider = 'gemini' | 'openai';
+
+/** Config resuelta del proveedor activo, lista para llamar al provider. */
+export interface ActiveAiConfig {
+  provider: AiProvider;
+  apiKey: string;
+  model: string;
+}
+
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
+
+/** Modelo por defecto según el proveedor, cuando la fila no lo tiene seteado. */
+function defaultModelFor(provider: AiProvider): string {
+  return provider === 'openai' ? DEFAULT_OPENAI_MODEL : DEFAULT_GEMINI_MODEL;
+}
+
+/**
+ * Devuelve la configuración del proveedor de AI ACTIVO (la fila
+ * `ai_provider_config` con `is_active = true`), con la API key ya descifrada.
+ *
+ * FALLBACK por compatibilidad: si no hay fila activa, o la fila activa no tiene
+ * `api_key` configurada, se usa `process.env.GEMINI_API_KEY` (provider
+ * `gemini`, modelo `GEMINI_MODEL` o el default). Si tampoco hay key en el
+ * entorno, lanza un Error claro.
+ *
+ * @throws Error si no hay ningún proveedor de AI configurado (ni en DB ni env).
+ */
+export async function getActiveAiConfig(): Promise<ActiveAiConfig> {
+  const row = await prisma.ai_provider_config.findFirst({
+    where: { is_active: true },
+  });
+
+  if (row && row.api_key) {
+    const provider: AiProvider = row.provider === 'openai' ? 'openai' : 'gemini';
+    return {
+      provider,
+      apiKey: decryptSecret(row.api_key),
+      model: row.model ?? defaultModelFor(provider),
+    };
+  }
+
+  // Fallback a la env (compatibilidad con el comportamiento previo).
+  const envKey = process.env.GEMINI_API_KEY;
+  if (envKey) {
+    return {
+      provider: 'gemini',
+      apiKey: envKey,
+      model: process.env.GEMINI_MODEL ?? DEFAULT_GEMINI_MODEL,
+    };
+  }
+
+  throw new Error('No hay proveedor de AI configurado.');
+}

--- a/src/modules/purchasing/shared/invoice-extraction/extract-invoice.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/extract-invoice.ts
@@ -1,0 +1,33 @@
+import 'server-only';
+
+import { getActiveAiConfig } from './ai-config';
+import { extractWithGemini } from './gemini-provider';
+import { extractWithOpenAI } from './openai-provider';
+import type { ExtractedInvoice, ExtractionFileInput } from './types';
+
+/**
+ * Capa swappable de extracción de facturas por AI.
+ *
+ * Resuelve el proveedor ACTIVO con `getActiveAiConfig` (lee la fila
+ * `ai_provider_config` activa de la DB, con la API key descifrada; cae a la env
+ * por compatibilidad) y rutea al provider correspondiente pasándole `apiKey` y
+ * `model`. El resto de la app consume siempre `extractInvoiceFromFile` y no
+ * necesita enterarse de qué proveedor hay detrás.
+ *
+ * Para sumar otro proveedor de AI: crear otro archivo `*-provider.ts` (mismo
+ * contrato `(file, opts) => Promise<ExtractedInvoice>`) y agregar un `case` en
+ * el ruteo de abajo.
+ */
+export async function extractInvoiceFromFile(
+  file: ExtractionFileInput
+): Promise<ExtractedInvoice> {
+  const cfg = await getActiveAiConfig();
+
+  switch (cfg.provider) {
+    case 'openai':
+      return extractWithOpenAI(file, cfg);
+    case 'gemini':
+    default:
+      return extractWithGemini(file, cfg);
+  }
+}

--- a/src/modules/purchasing/shared/invoice-extraction/gemini-provider.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/gemini-provider.ts
@@ -1,0 +1,224 @@
+import 'server-only';
+
+import {
+  ExtractedInvoiceSchema,
+  type ExtractedInvoice,
+  type ExtractionFileInput,
+} from './types';
+
+const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/models';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+
+/**
+ * Esperas (ms) entre reintentos ante respuestas de servicio saturado
+ * (503 UNAVAILABLE / 429 RESOURCE_EXHAUSTED). El nº de elementos define el
+ * máximo de reintentos: tras `RETRY_DELAYS_MS.length` esperas fallidas, se
+ * propaga el error.
+ */
+const RETRY_DELAYS_MS = [1500, 3000, 5000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Opciones de ejecución del provider (resueltas desde la config activa). */
+export interface GeminiProviderOptions {
+  apiKey: string;
+  model: string;
+}
+
+/**
+ * Schema de respuesta en el subset de OpenAPI que acepta Gemini
+ * (`responseSchema`). Los `type` van en MAYÚSCULAS y `nullable: true` permite
+ * que la AI devuelva `null` cuando un dato no aparece en el comprobante.
+ *
+ * Verificado contra el endpoint real (gemini-2.5-flash) con un archivo de
+ * prueba: devuelve 200 y JSON válido respetando este shape.
+ */
+const GEMINI_RESPONSE_SCHEMA = {
+  type: 'OBJECT',
+  properties: {
+    razon_social: { type: 'STRING', nullable: true },
+    cuit: { type: 'STRING', nullable: true },
+    voucher_type: { type: 'STRING', nullable: true },
+    point_of_sale: { type: 'STRING', nullable: true },
+    number: { type: 'STRING', nullable: true },
+    issue_date: { type: 'STRING', nullable: true },
+    due_date: { type: 'STRING', nullable: true },
+    cae: { type: 'STRING', nullable: true },
+    total: { type: 'NUMBER', nullable: true },
+    lines: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          description: { type: 'STRING', nullable: true },
+          quantity: { type: 'NUMBER', nullable: true },
+          unit_cost: { type: 'NUMBER', nullable: true },
+          vat_rate: { type: 'NUMBER', nullable: true },
+        },
+      },
+    },
+  },
+  required: [
+    'razon_social',
+    'cuit',
+    'voucher_type',
+    'point_of_sale',
+    'number',
+    'issue_date',
+    'due_date',
+    'cae',
+    'total',
+    'lines',
+  ],
+} as const;
+
+export const EXTRACTION_PROMPT = `Sos un asistente experto en facturas de compra argentinas (comprobantes AFIP).
+Analizá el comprobante adjunto (factura, nota de crédito, nota de débito o recibo) y extraé los siguientes datos.
+
+Devolvé SOLO un objeto JSON con estos campos. Si un dato no aparece en el comprobante, devolvé null (no inventes datos):
+
+- razon_social: razón social o nombre del EMISOR del comprobante (el proveedor / vendedor), NO del receptor.
+- cuit: CUIT del emisor (proveedor), solo los dígitos o con guiones, tal como aparece.
+- voucher_type: tipo de comprobante. Usá EXACTAMENTE uno de estos valores según corresponda:
+  "FACTURA_A", "FACTURA_B", "FACTURA_C",
+  "NOTA_CREDITO_A", "NOTA_CREDITO_B", "NOTA_CREDITO_C",
+  "NOTA_DEBITO_A", "NOTA_DEBITO_B", "NOTA_DEBITO_C",
+  "RECIBO".
+  La letra (A/B/C) suele estar en un recuadro destacado junto al tipo de comprobante (ej. "FACTURA" + "A").
+- point_of_sale: punto de venta, los primeros dígitos del número de comprobante (ej. en "0001-00001234" es "0001"). Solo los dígitos.
+- number: número del comprobante, la segunda parte luego del guión (ej. en "0001-00001234" es "00001234"). Solo los dígitos.
+- issue_date: fecha de emisión en formato YYYY-MM-DD.
+- due_date: fecha de vencimiento del comprobante en formato YYYY-MM-DD, si existe.
+- cae: número de CAE / CAEA del comprobante, si aparece.
+- total: importe total del comprobante como número (sin símbolo de moneda ni separadores de miles; usá punto como separador decimal).
+- lines: array con los ítems/renglones del comprobante. Por cada ítem:
+  - description: descripción del producto o servicio.
+  - quantity: cantidad como número.
+  - unit_cost: precio unitario SIN IVA como número. Si solo figura el precio con IVA, devolvé ese valor igual.
+  - vat_rate: alícuota de IVA del ítem como número (ej. 21, 10.5, 27, 0). Si no se discrimina por ítem, devolvé null.
+
+Los importes deben ser números (no strings). Las fechas en formato YYYY-MM-DD.`;
+
+interface GeminiResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{ text?: string }>;
+    };
+    finishReason?: string;
+  }>;
+  error?: { message?: string };
+}
+
+/**
+ * Extrae los datos de una factura de compra usando Gemini (REST, sin SDK).
+ *
+ * La API key y el modelo se reciben por `opts` (los resuelve la capa de config
+ * `getActiveAiConfig`, que lee la DB o cae a la env). Envía el archivo como
+ * `inlineData` (base64) + un prompt de extracción y pide la respuesta
+ * estructurada vía `responseSchema`.
+ *
+ * REINTENTO: si Gemini responde 503 (UNAVAILABLE) o 429 (RESOURCE_EXHAUSTED) —
+ * servicio saturado / rate limit —, reintenta con backoff creciente
+ * (~1.5s, 3s, 5s) hasta agotar `RETRY_DELAYS_MS`. Otros errores (4xx, parseo)
+ * no se reintentan: se propagan de inmediato.
+ *
+ * @throws Error con mensaje claro si Gemini responde con error (tras agotar
+ *   reintentos en el caso 503/429), o si la respuesta no es JSON válido / no
+ *   cumple `ExtractedInvoiceSchema`.
+ */
+export async function extractWithGemini(
+  file: ExtractionFileInput,
+  opts: GeminiProviderOptions
+): Promise<ExtractedInvoice> {
+  const model = opts.model || DEFAULT_MODEL;
+  const url = `${GEMINI_ENDPOINT}/${model}:generateContent`;
+
+  const body = {
+    contents: [
+      {
+        parts: [
+          { inlineData: { mimeType: file.mimeType, data: file.base64 } },
+          { text: EXTRACTION_PROMPT },
+        ],
+      },
+    ],
+    generationConfig: {
+      responseMimeType: 'application/json',
+      responseSchema: GEMINI_RESPONSE_SCHEMA,
+    },
+  };
+
+  let rawText = '';
+  // Reintenta solo ante 503/429; cualquier otro fallo rompe el loop y propaga.
+  for (let attempt = 0; ; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': opts.apiKey,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new Error(
+        `No se pudo conectar con el servicio de lectura de facturas: ${
+          error instanceof Error ? error.message : 'error desconocido'
+        }`
+      );
+    }
+
+    rawText = await response.text();
+
+    if (response.ok) {
+      break;
+    }
+
+    const retriable = response.status === 503 || response.status === 429;
+    if (retriable && attempt < RETRY_DELAYS_MS.length) {
+      await sleep(RETRY_DELAYS_MS[attempt]);
+      continue;
+    }
+
+    let detail = rawText;
+    try {
+      const parsed = JSON.parse(rawText) as GeminiResponse;
+      detail = parsed.error?.message ?? rawText;
+    } catch {
+      // se usa rawText tal cual
+    }
+    throw new Error(
+      `El servicio de lectura de facturas devolvió un error (${response.status}): ${detail}`
+    );
+  }
+
+  let parsed: GeminiResponse;
+  try {
+    parsed = JSON.parse(rawText) as GeminiResponse;
+  } catch {
+    throw new Error('La respuesta del servicio de lectura de facturas no es JSON válido.');
+  }
+
+  const candidate = parsed.candidates?.[0];
+  const text = candidate?.content?.parts?.[0]?.text;
+  if (!text) {
+    throw new Error('El servicio de lectura de facturas no devolvió ningún dato extraído.');
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error('Los datos extraídos de la factura no tienen un formato JSON válido.');
+  }
+
+  const result = ExtractedInvoiceSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error('Los datos extraídos de la factura no tienen el formato esperado.');
+  }
+
+  return result.data;
+}

--- a/src/modules/purchasing/shared/invoice-extraction/map-to-form.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/map-to-form.ts
@@ -1,0 +1,229 @@
+import { z } from 'zod';
+import { purchaseInvoiceSchema } from '@/modules/purchasing/shared/validators';
+import type { ExtractedInvoice } from './types';
+
+/**
+ * Mapeo del resultado crudo de la AI (`ExtractedInvoice`) a valores
+ * pre-cargables del formulario de Factura de Compra (`purchaseInvoiceSchema`),
+ * más el match de proveedor por CUIT y la lista de campos de baja confianza
+ * (los que vinieron `null` o no se pudieron normalizar) para que la UI los
+ * marque como "Revisar".
+ *
+ * Función PURA: no toca DB, no es server action. Recibe la lista de proveedores
+ * ya pre-cargada (la page del form ya pre-fetcha suppliers).
+ */
+
+export type PurchaseInvoiceFormValues = z.infer<typeof purchaseInvoiceSchema>;
+
+/** Proveedor mínimo necesario para el match por CUIT. */
+export interface SupplierForMatch {
+  id: string;
+  business_name: string;
+  tax_id: string | null;
+}
+
+export interface MappedInvoiceLine {
+  description: string;
+  quantity: number;
+  unit_cost: number;
+  vat_rate: number;
+}
+
+export interface SupplierMatchResult {
+  matched: boolean;
+  supplierId: string | null;
+  /** CUIT extraído normalizado (solo dígitos) o null si no vino. */
+  cuit: string | null;
+  /** Razón social extraída (cruda) o null si no vino. */
+  razonSocial: string | null;
+}
+
+export interface MapExtractedToFormResult {
+  /**
+   * Valores parciales para pre-llenar el form. Solo se incluyen las claves que
+   * pudimos resolver con confianza; el resto se deja sin setear para que la UI
+   * conserve sus defaults. `lines` siempre se incluye (puede ser `[]`).
+   */
+  values: Partial<PurchaseInvoiceFormValues>;
+  supplierMatch: SupplierMatchResult;
+  /** Nombres de campos (cabecera) que vinieron null o dudosos, para "Revisar". */
+  lowConfidenceFields: string[];
+}
+
+/** Enums válidos de comprobante, tomados del schema (fuente de verdad). */
+const VOUCHER_TYPES = [
+  'FACTURA_A',
+  'FACTURA_B',
+  'FACTURA_C',
+  'NOTA_CREDITO_A',
+  'NOTA_CREDITO_B',
+  'NOTA_CREDITO_C',
+  'NOTA_DEBITO_A',
+  'NOTA_DEBITO_B',
+  'NOTA_DEBITO_C',
+  'RECIBO',
+] as const;
+
+type VoucherType = (typeof VOUCHER_TYPES)[number];
+
+/** Quita todo lo que no sea dígito (guiones, espacios, puntos). */
+function normalizeCuit(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const digits = value.replace(/\D/g, '');
+  return digits.length > 0 ? digits : null;
+}
+
+/** `true` si el string tiene contenido real tras trim. */
+function hasText(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Normaliza el texto que devuelve la AI para el tipo de comprobante a uno de
+ * los enums válidos. Tolera variantes: "Factura A", "FACTURA_A", "FAC A",
+ * "Nota de Crédito B", "NC B", "A" (suelto → Factura A), etc. Devuelve el enum
+ * o `null` si no se puede mapear con confianza.
+ */
+function normalizeVoucherType(raw: string | null | undefined): VoucherType | null {
+  if (!hasText(raw)) return null;
+
+  // Si ya viene como enum exacto, atajo.
+  const exact = raw.trim().toUpperCase().replace(/\s+/g, '_');
+  if ((VOUCHER_TYPES as readonly string[]).includes(exact)) {
+    return exact as VoucherType;
+  }
+
+  // Normalización fonética/canónica: minúsculas, sin tildes, sin signos.
+  const canon = raw
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // quita tildes (diacríticos combinados)
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Detectar la letra/clase del comprobante (A/B/C). Buscamos una letra suelta.
+  const letterMatch = canon.match(/(?:^|\s)([abc])(?:\s|$)/);
+  const letter = letterMatch ? letterMatch[1].toUpperCase() : null;
+
+  const isNotaCredito = /\bnc\b/.test(canon) || /nota.*credito/.test(canon);
+  const isNotaDebito = /\bnd\b/.test(canon) || /nota.*debito/.test(canon);
+  const isFactura = /\bfac\b/.test(canon) || /\bfactura\b/.test(canon) || /\bfc\b/.test(canon);
+  const isRecibo = /\brecibo\b/.test(canon);
+
+  if (isRecibo) return 'RECIBO';
+
+  if (letter) {
+    if (isNotaCredito) return `NOTA_CREDITO_${letter}` as VoucherType;
+    if (isNotaDebito) return `NOTA_DEBITO_${letter}` as VoucherType;
+    // Factura explícita, o solo la letra suelta → asumimos Factura de ese tipo.
+    if (isFactura || canon === letter.toLowerCase()) {
+      return `FACTURA_${letter}` as VoucherType;
+    }
+    // Hay letra pero clase ambigua → no arriesgamos.
+    return null;
+  }
+
+  return null;
+}
+
+/** Fecha válida si matchea YYYY-MM-DD; si no, null. */
+function normalizeIsoDate(value: string | null | undefined): string | null {
+  if (!hasText(value)) return null;
+  const v = value.trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : null;
+}
+
+export function mapExtractedToForm(
+  extracted: ExtractedInvoice,
+  suppliers: SupplierForMatch[],
+): MapExtractedToFormResult {
+  const values: Partial<PurchaseInvoiceFormValues> = {};
+  const lowConfidenceFields: string[] = [];
+
+  // --- Match de proveedor por CUIT ---------------------------------------
+  const extractedCuit = normalizeCuit(extracted.cuit);
+  let supplierId: string | null = null;
+
+  if (extractedCuit) {
+    const match = suppliers.find((s) => normalizeCuit(s.tax_id) === extractedCuit);
+    if (match) supplierId = match.id;
+  }
+
+  const supplierMatch: SupplierMatchResult = {
+    matched: supplierId !== null,
+    supplierId,
+    cuit: extractedCuit,
+    razonSocial: hasText(extracted.razon_social) ? extracted.razon_social.trim() : null,
+  };
+
+  if (supplierId) {
+    values.supplier_id = supplierId;
+  } else {
+    // No se pudo resolver el proveedor: la UI ofrece crearlo / elegirlo.
+    lowConfidenceFields.push('supplier_id');
+  }
+
+  // --- voucher_type -------------------------------------------------------
+  const voucherType = normalizeVoucherType(extracted.voucher_type);
+  if (voucherType) {
+    values.voucher_type = voucherType;
+  } else {
+    lowConfidenceFields.push('voucher_type');
+  }
+
+  // --- point_of_sale (string max 5) --------------------------------------
+  if (hasText(extracted.point_of_sale)) {
+    values.point_of_sale = extracted.point_of_sale.trim().slice(0, 5);
+  } else {
+    lowConfidenceFields.push('point_of_sale');
+  }
+
+  // --- number (string max 20) --------------------------------------------
+  if (hasText(extracted.number)) {
+    values.number = extracted.number.trim().slice(0, 20);
+  } else {
+    lowConfidenceFields.push('number');
+  }
+
+  // --- issue_date (YYYY-MM-DD requerido) ---------------------------------
+  const issueDate = normalizeIsoDate(extracted.issue_date);
+  if (issueDate) {
+    values.issue_date = issueDate;
+  } else {
+    lowConfidenceFields.push('issue_date');
+  }
+
+  // --- due_date (opcional) -----------------------------------------------
+  const dueDate = normalizeIsoDate(extracted.due_date);
+  if (dueDate) {
+    values.due_date = dueDate;
+  } else if (extracted.due_date !== null) {
+    // Vino algo pero no parseó como fecha → dudoso.
+    lowConfidenceFields.push('due_date');
+  }
+
+  // --- cae (opcional) -----------------------------------------------------
+  if (hasText(extracted.cae)) {
+    values.cae = extracted.cae.trim();
+  }
+  // CAE ausente no es "dudoso": muchas facturas (B/C) no lo muestran.
+
+  // --- lines --------------------------------------------------------------
+  const lines: MappedInvoiceLine[] = extracted.lines.map((line) => ({
+    description: hasText(line.description) ? line.description.trim() : '',
+    quantity: typeof line.quantity === 'number' && line.quantity > 0 ? line.quantity : 1,
+    unit_cost: typeof line.unit_cost === 'number' && line.unit_cost >= 0 ? line.unit_cost : 0,
+    vat_rate: typeof line.vat_rate === 'number' && line.vat_rate >= 0 ? line.vat_rate : 21,
+  }));
+
+  values.lines = lines;
+  if (lines.length === 0) {
+    lowConfidenceFields.push('lines');
+  } else if (lines.some((l) => l.description === '')) {
+    // Alguna línea quedó sin descripción → marcar para revisar.
+    lowConfidenceFields.push('lines');
+  }
+
+  return { values, supplierMatch, lowConfidenceFields };
+}

--- a/src/modules/purchasing/shared/invoice-extraction/openai-provider.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/openai-provider.ts
@@ -1,0 +1,206 @@
+import 'server-only';
+
+import {
+  ExtractedInvoiceSchema,
+  type ExtractedInvoice,
+  type ExtractionFileInput,
+} from './types';
+import { EXTRACTION_PROMPT } from './gemini-provider';
+
+const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = 'gpt-4o-mini';
+
+/**
+ * Esperas (ms) entre reintentos ante respuestas de servicio saturado
+ * (429 rate limit / 503 service unavailable). El nº de elementos define el
+ * máximo de reintentos.
+ */
+const RETRY_DELAYS_MS = [1500, 3000, 5000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Opciones de ejecución del provider (resueltas desde la config activa). */
+export interface OpenAiProviderOptions {
+  apiKey: string;
+  model: string;
+}
+
+/**
+ * `json_schema` de OpenAI (subset de JSON Schema). A diferencia de Gemini, los
+ * `type` van en minúsculas y los campos opcionales se expresan como union con
+ * `"null"`. `strict: true` exige que el modelo respete el shape exactamente.
+ */
+const OPENAI_RESPONSE_SCHEMA = {
+  name: 'extracted_invoice',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      razon_social: { type: ['string', 'null'] },
+      cuit: { type: ['string', 'null'] },
+      voucher_type: { type: ['string', 'null'] },
+      point_of_sale: { type: ['string', 'null'] },
+      number: { type: ['string', 'null'] },
+      issue_date: { type: ['string', 'null'] },
+      due_date: { type: ['string', 'null'] },
+      cae: { type: ['string', 'null'] },
+      total: { type: ['number', 'null'] },
+      lines: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            description: { type: ['string', 'null'] },
+            quantity: { type: ['number', 'null'] },
+            unit_cost: { type: ['number', 'null'] },
+            vat_rate: { type: ['number', 'null'] },
+          },
+          required: ['description', 'quantity', 'unit_cost', 'vat_rate'],
+        },
+      },
+    },
+    required: [
+      'razon_social',
+      'cuit',
+      'voucher_type',
+      'point_of_sale',
+      'number',
+      'issue_date',
+      'due_date',
+      'cae',
+      'total',
+      'lines',
+    ],
+  },
+} as const;
+
+interface OpenAiResponse {
+  choices?: Array<{
+    message?: { content?: string | null };
+    finish_reason?: string;
+  }>;
+  error?: { message?: string };
+}
+
+/**
+ * Extrae los datos de una factura de compra usando OpenAI Chat Completions
+ * (REST, sin SDK). El archivo se envía como `image_url` con data URL
+ * (`data:${mimeType};base64,${base64}`) + el prompt de extracción compartido,
+ * y se pide la salida estructurada con `response_format: json_schema`.
+ *
+ * LIMITACIÓN: el endpoint de chat NO acepta PDF como `image_url`. Si el archivo
+ * es `application/pdf`, se lanza un Error claro pidiendo usar Gemini o una
+ * imagen.
+ *
+ * REINTENTO: ante 429 (rate limit) o 503 (unavailable) reintenta con backoff
+ * creciente (~1.5s, 3s, 5s). Otros errores se propagan de inmediato.
+ *
+ * @throws Error si el archivo es PDF, si OpenAI responde con error (tras agotar
+ *   reintentos en 429/503), o si la respuesta no es JSON válido / no cumple
+ *   `ExtractedInvoiceSchema`.
+ */
+export async function extractWithOpenAI(
+  file: ExtractionFileInput,
+  opts: OpenAiProviderOptions
+): Promise<ExtractedInvoice> {
+  if (file.mimeType === 'application/pdf') {
+    throw new Error(
+      'OpenAI no soporta PDF directamente; usá Gemini para PDFs o subí una imagen (JPG/PNG).'
+    );
+  }
+
+  const model = opts.model || DEFAULT_MODEL;
+  const dataUrl = `data:${file.mimeType};base64,${file.base64}`;
+
+  const body = {
+    model,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: EXTRACTION_PROMPT },
+          { type: 'image_url', image_url: { url: dataUrl } },
+        ],
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: OPENAI_RESPONSE_SCHEMA,
+    },
+  };
+
+  let rawText = '';
+  // Reintenta solo ante 429/503; cualquier otro fallo rompe el loop y propaga.
+  for (let attempt = 0; ; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(OPENAI_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${opts.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new Error(
+        `No se pudo conectar con el servicio de lectura de facturas: ${
+          error instanceof Error ? error.message : 'error desconocido'
+        }`
+      );
+    }
+
+    rawText = await response.text();
+
+    if (response.ok) {
+      break;
+    }
+
+    const retriable = response.status === 429 || response.status === 503;
+    if (retriable && attempt < RETRY_DELAYS_MS.length) {
+      await sleep(RETRY_DELAYS_MS[attempt]);
+      continue;
+    }
+
+    let detail = rawText;
+    try {
+      const parsed = JSON.parse(rawText) as OpenAiResponse;
+      detail = parsed.error?.message ?? rawText;
+    } catch {
+      // se usa rawText tal cual
+    }
+    throw new Error(
+      `El servicio de lectura de facturas devolvió un error (${response.status}): ${detail}`
+    );
+  }
+
+  let parsed: OpenAiResponse;
+  try {
+    parsed = JSON.parse(rawText) as OpenAiResponse;
+  } catch {
+    throw new Error('La respuesta del servicio de lectura de facturas no es JSON válido.');
+  }
+
+  const text = parsed.choices?.[0]?.message?.content;
+  if (!text) {
+    throw new Error('El servicio de lectura de facturas no devolvió ningún dato extraído.');
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error('Los datos extraídos de la factura no tienen un formato JSON válido.');
+  }
+
+  const result = ExtractedInvoiceSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error('Los datos extraídos de la factura no tienen el formato esperado.');
+  }
+
+  return result.data;
+}

--- a/src/modules/purchasing/shared/invoice-extraction/types.ts
+++ b/src/modules/purchasing/shared/invoice-extraction/types.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Resultado de la extracción de datos de una factura de compra por AI.
+ *
+ * Todos los campos de cabecera son `string | null` (o `number | null` para
+ * importes), porque la AI puede no encontrar un dato en el comprobante. El
+ * mapeo a los campos del formulario (`purchaseInvoiceSchema`) se hace en un
+ * lote posterior; acá solo describimos lo que la AI devuelve "crudo".
+ *
+ * `voucher_type` se devuelve como string libre (ej. "FACTURA_A"); el prompt le
+ * pide a la AI que use uno de los valores válidos del enum de comprobantes,
+ * pero NO lo validamos contra el enum acá para no perder la extracción si la AI
+ * devuelve algo levemente distinto. La normalización es responsabilidad del
+ * mapeo posterior.
+ */
+export const ExtractedInvoiceLineSchema = z.object({
+  description: z.string().nullable(),
+  quantity: z.number().nullable(),
+  unit_cost: z.number().nullable(),
+  vat_rate: z.number().nullable(),
+});
+
+export const ExtractedInvoiceSchema = z.object({
+  razon_social: z.string().nullable(),
+  cuit: z.string().nullable(),
+  voucher_type: z.string().nullable(),
+  point_of_sale: z.string().nullable(),
+  number: z.string().nullable(),
+  issue_date: z.string().nullable(),
+  due_date: z.string().nullable(),
+  cae: z.string().nullable(),
+  total: z.number().nullable(),
+  lines: z.array(ExtractedInvoiceLineSchema),
+});
+
+export type ExtractedInvoiceLine = z.infer<typeof ExtractedInvoiceLineSchema>;
+export type ExtractedInvoice = z.infer<typeof ExtractedInvoiceSchema>;
+
+/**
+ * Archivo de entrada para los providers de extracción: el contenido ya
+ * convertido a base64 (sin el prefijo `data:`) y su MIME type.
+ */
+export interface ExtractionFileInput {
+  base64: string;
+  mimeType: string;
+}

--- a/src/modules/settings/features/ai/actions.server.ts
+++ b/src/modules/settings/features/ai/actions.server.ts
@@ -1,0 +1,240 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { prisma } from '@/shared/lib/prisma';
+import { getSession } from '@/shared/lib/session';
+import { encryptSecret, decryptSecret } from '@/shared/lib/crypto';
+
+/** Proveedores de AI configurables para la lectura de facturas. */
+export type AiProvider = 'gemini' | 'openai';
+
+const PROVIDERS: AiProvider[] = ['gemini', 'openai'];
+
+const DEFAULT_MODELS: Record<AiProvider, string> = {
+  gemini: 'gemini-2.5-flash',
+  openai: 'gpt-4o-mini',
+};
+
+/** Vista segura de la config de un proveedor para el cliente (sin la key). */
+export interface AiProviderConfigView {
+  provider: AiProvider;
+  model: string | null;
+  isActive: boolean;
+  hasKey: boolean;
+}
+
+const ADMIN_ROLES = ['Admin', 'Super Admin', 'Developer'];
+
+/**
+ * Valida que el usuario pueda administrar la config global de IA:
+ * admin de plataforma o dueño (owner) de la empresa activa.
+ */
+async function ensureCanManageAi(): Promise<{ error: string } | null> {
+  const s = await getSession();
+  const isPlatformAdmin = ADMIN_ROLES.includes(s.profile?.role ?? '');
+  const isOwner = s.role === 'owner';
+  if (!isPlatformAdmin && !isOwner) {
+    return { error: 'Sin permisos' };
+  }
+  return null;
+}
+
+/**
+ * Devuelve la config de cada proveedor soportado (gemini, openai) en una vista
+ * segura: NUNCA expone la `api_key` descifrada, solo `hasKey: boolean`. Si un
+ * proveedor todavía no tiene fila, se devuelve con `hasKey=false`,
+ * `isActive=false` y el modelo por defecto sugerido.
+ */
+export async function getAiProviderConfigs(): Promise<AiProviderConfigView[]> {
+  const denied = await ensureCanManageAi();
+  if (denied) return [];
+
+  const rows = await prisma.ai_provider_config.findMany();
+  const byProvider = new Map(rows.map((r) => [r.provider, r]));
+
+  return PROVIDERS.map((provider) => {
+    const row = byProvider.get(provider);
+    return {
+      provider,
+      model: row?.model ?? DEFAULT_MODELS[provider],
+      isActive: row?.is_active ?? false,
+      hasKey: Boolean(row?.api_key),
+    };
+  });
+}
+
+export interface UpsertAiProviderConfigInput {
+  provider: AiProvider;
+  /** Si viene no-vacía, se cifra y reemplaza. Vacía/undefined = preservar la actual. */
+  apiKey?: string;
+  model?: string;
+  isActive: boolean;
+}
+
+/**
+ * Crea/actualiza la config de un proveedor. Reglas:
+ * - `apiKey` no-vacía → se cifra con `encryptSecret` y se guarda. Vacía/undefined
+ *   → NO se toca la key existente (se preserva).
+ * - `isActive=true` → exclusividad: pone `is_active=false` en las demás filas y
+ *   `true` en esta (en una transacción).
+ */
+export async function upsertAiProviderConfig(input: UpsertAiProviderConfigInput) {
+  const denied = await ensureCanManageAi();
+  if (denied) return denied;
+
+  if (!PROVIDERS.includes(input.provider)) {
+    return { error: 'Proveedor inválido' };
+  }
+
+  try {
+    const apiKey = input.apiKey?.trim();
+    const model = input.model?.trim() || null;
+    const encryptedKey = apiKey ? encryptSecret(apiKey) : undefined;
+
+    await prisma.$transaction(async (tx) => {
+      // Exclusividad del activo: si esta fila pasa a activa, desactivar el resto.
+      if (input.isActive) {
+        await tx.ai_provider_config.updateMany({
+          where: { provider: { not: input.provider } },
+          data: { is_active: false },
+        });
+      }
+
+      await tx.ai_provider_config.upsert({
+        where: { provider: input.provider },
+        update: {
+          model,
+          is_active: input.isActive,
+          ...(encryptedKey !== undefined ? { api_key: encryptedKey } : {}),
+        },
+        create: {
+          provider: input.provider,
+          model,
+          is_active: input.isActive,
+          api_key: encryptedKey ?? null,
+        },
+      });
+    });
+
+    revalidatePath('/dashboard/settings');
+    return { error: null };
+  } catch (error) {
+    console.error('Error upserting ai_provider_config:', error);
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Llama de forma liviana al proveedor (un request chico de texto, sin factura)
+ * usando la key GUARDADA y descifrada en el server, para confirmar que
+ * autentica correctamente. NUNCA devuelve la key al cliente.
+ */
+export async function testAiProviderConnection(
+  provider: AiProvider
+): Promise<{ ok: boolean; message: string }> {
+  const denied = await ensureCanManageAi();
+  if (denied) return { ok: false, message: denied.error };
+
+  if (!PROVIDERS.includes(provider)) {
+    return { ok: false, message: 'Proveedor inválido' };
+  }
+
+  const row = await prisma.ai_provider_config.findUnique({ where: { provider } });
+  if (!row?.api_key) {
+    return { ok: false, message: 'No hay API key configurada para este proveedor.' };
+  }
+
+  let apiKey: string;
+  try {
+    apiKey = decryptSecret(row.api_key);
+  } catch {
+    return { ok: false, message: 'No se pudo descifrar la API key guardada.' };
+  }
+
+  const model = row.model ?? DEFAULT_MODELS[provider];
+
+  try {
+    if (provider === 'gemini') {
+      return await testGemini(apiKey, model);
+    }
+    return await testOpenAI(apiKey, model);
+  } catch (error) {
+    return {
+      ok: false,
+      message: `No se pudo conectar: ${
+        error instanceof Error ? error.message : 'error desconocido'
+      }`,
+    };
+  }
+}
+
+/** Request mínimo de texto a Gemini para validar la key/modelo. */
+async function testGemini(
+  apiKey: string,
+  model: string
+): Promise<{ ok: boolean; message: string }> {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: 'ping' }] }],
+      generationConfig: { maxOutputTokens: 1 },
+    }),
+  });
+
+  if (response.ok) {
+    return { ok: true, message: `Conexión correcta con Gemini (${model}).` };
+  }
+
+  let detail = '';
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    detail = body.error?.message ?? '';
+  } catch {
+    // sin detalle
+  }
+  return {
+    ok: false,
+    message: `Gemini respondió ${response.status}${detail ? `: ${detail}` : ''}`,
+  };
+}
+
+/** Request mínimo de texto a OpenAI para validar la key/modelo. */
+async function testOpenAI(
+  apiKey: string,
+  model: string
+): Promise<{ ok: boolean; message: string }> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: 'ping' }],
+      max_tokens: 1,
+    }),
+  });
+
+  if (response.ok) {
+    return { ok: true, message: `Conexión correcta con OpenAI (${model}).` };
+  }
+
+  let detail = '';
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    detail = body.error?.message ?? '';
+  } catch {
+    // sin detalle
+  }
+  return {
+    ok: false,
+    message: `OpenAI respondió ${response.status}${detail ? `: ${detail}` : ''}`,
+  };
+}

--- a/src/modules/settings/features/ai/components/AiProviderSettingsForm.tsx
+++ b/src/modules/settings/features/ai/components/AiProviderSettingsForm.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
+
+import { Button } from '@/shared/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/components/ui/card';
+import { Input } from '@/shared/components/ui/input';
+import { Label } from '@/shared/components/ui/label';
+import { Badge } from '@/shared/components/ui/badge';
+import { RadioGroup, RadioGroupItem } from '@/shared/components/ui/radio-group';
+
+import {
+  upsertAiProviderConfig,
+  testAiProviderConnection,
+  type AiProvider,
+  type AiProviderConfigView,
+} from '../actions.server';
+
+interface Props {
+  initial: AiProviderConfigView[];
+}
+
+interface ProviderMeta {
+  provider: AiProvider;
+  label: string;
+  defaultModel: string;
+  modelHint: string;
+  keyHint: string;
+}
+
+const PROVIDER_META: ProviderMeta[] = [
+  {
+    provider: 'gemini',
+    label: 'Google Gemini',
+    defaultModel: 'gemini-2.5-flash',
+    modelHint: 'Ej: gemini-2.5-flash. Soporta imágenes y PDF.',
+    keyHint: 'Clave de Google AI Studio (Gemini API).',
+  },
+  {
+    provider: 'openai',
+    label: 'OpenAI (ChatGPT)',
+    defaultModel: 'gpt-4o-mini',
+    modelHint: 'Ej: gpt-4o-mini. Solo imágenes (no PDF directo).',
+    keyHint: 'Clave de plataforma OpenAI (sk-...).',
+  },
+];
+
+interface DraftState {
+  apiKey: string;
+  model: string;
+}
+
+type TestResult = { ok: boolean; message: string } | null;
+
+export function AiProviderSettingsForm({ initial }: Props) {
+  const router = useRouter();
+  const [isSaving, startSave] = useTransition();
+
+  const byProvider = new Map(initial.map((c) => [c.provider, c]));
+
+  const activeFromInitial =
+    initial.find((c) => c.isActive)?.provider ?? 'gemini';
+
+  const [activeProvider, setActiveProvider] = useState<AiProvider>(activeFromInitial);
+
+  const [drafts, setDrafts] = useState<Record<AiProvider, DraftState>>(() => {
+    const base = {} as Record<AiProvider, DraftState>;
+    for (const meta of PROVIDER_META) {
+      const cfg = byProvider.get(meta.provider);
+      base[meta.provider] = {
+        apiKey: '',
+        model: cfg?.model ?? meta.defaultModel,
+      };
+    }
+    return base;
+  });
+
+  const [testing, setTesting] = useState<Record<AiProvider, boolean>>({
+    gemini: false,
+    openai: false,
+  });
+  const [testResults, setTestResults] = useState<Record<AiProvider, TestResult>>({
+    gemini: null,
+    openai: null,
+  });
+
+  const setDraft = (provider: AiProvider, patch: Partial<DraftState>) =>
+    setDrafts((prev) => ({ ...prev, [provider]: { ...prev[provider], ...patch } }));
+
+  const handleTest = (provider: AiProvider) => {
+    setTesting((prev) => ({ ...prev, [provider]: true }));
+    setTestResults((prev) => ({ ...prev, [provider]: null }));
+    void (async () => {
+      try {
+        const result = await testAiProviderConnection(provider);
+        setTestResults((prev) => ({ ...prev, [provider]: result }));
+        if (result.ok) {
+          toast.success('Conexión correcta', { description: result.message });
+        } else {
+          toast.error('Falló la conexión', { description: result.message });
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'Error desconocido';
+        setTestResults((prev) => ({ ...prev, [provider]: { ok: false, message } }));
+        toast.error('Falló la conexión', { description: message });
+      } finally {
+        setTesting((prev) => ({ ...prev, [provider]: false }));
+      }
+    })();
+  };
+
+  const handleSave = () => {
+    startSave(async () => {
+      // Guardamos cada proveedor; el activo lleva isActive=true (exclusividad
+      // la resuelve la server action). El apiKey vacío preserva la key actual.
+      for (const meta of PROVIDER_META) {
+        const draft = drafts[meta.provider];
+        const result = await upsertAiProviderConfig({
+          provider: meta.provider,
+          apiKey: draft.apiKey.trim() || undefined,
+          model: draft.model.trim() || undefined,
+          isActive: activeProvider === meta.provider,
+        });
+        if (result.error) {
+          toast.error('Error al guardar', {
+            description: `${meta.label}: ${result.error}`,
+          });
+          return;
+        }
+      }
+      toast.success('Configuración de IA guardada');
+      // Limpiar los inputs de key (ya quedaron persistidos cifrados).
+      setDrafts((prev) => {
+        const next = { ...prev };
+        for (const meta of PROVIDER_META) {
+          next[meta.provider] = { ...next[meta.provider], apiKey: '' };
+        }
+        return next;
+      });
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Proveedor activo</CardTitle>
+          <CardDescription>
+            Motor de IA que se usará para leer las facturas. Solo uno puede estar
+            activo a la vez.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={activeProvider}
+            onValueChange={(v) => setActiveProvider(v as AiProvider)}
+            disabled={isSaving}
+            aria-label="Proveedor de IA activo"
+          >
+            {PROVIDER_META.map((meta) => (
+              <label
+                key={meta.provider}
+                htmlFor={`active-${meta.provider}`}
+                className="flex items-center gap-3 text-sm cursor-pointer"
+              >
+                <RadioGroupItem value={meta.provider} id={`active-${meta.provider}`} />
+                <span>{meta.label}</span>
+                {byProvider.get(meta.provider)?.hasKey ? (
+                  <Badge variant="secondary">Key configurada</Badge>
+                ) : (
+                  <Badge variant="outline">Sin key</Badge>
+                )}
+              </label>
+            ))}
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {PROVIDER_META.map((meta) => {
+        const cfg = byProvider.get(meta.provider);
+        const draft = drafts[meta.provider];
+        const result = testResults[meta.provider];
+        const isTesting = testing[meta.provider];
+        const keyInputId = `apikey-${meta.provider}`;
+        const modelInputId = `model-${meta.provider}`;
+
+        return (
+          <Card key={meta.provider}>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                {meta.label}
+                {activeProvider === meta.provider && (
+                  <Badge variant="success">Activo</Badge>
+                )}
+              </CardTitle>
+              <CardDescription>{meta.keyHint}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor={keyInputId}>API key</Label>
+                <Input
+                  id={keyInputId}
+                  type="password"
+                  autoComplete="off"
+                  aria-describedby={`${keyInputId}-hint`}
+                  value={draft.apiKey}
+                  onChange={(e) => setDraft(meta.provider, { apiKey: e.target.value })}
+                  placeholder={cfg?.hasKey ? '•••• configurada (dejar vacío para mantener)' : 'Pegá la API key'}
+                  disabled={isSaving}
+                />
+                <p id={`${keyInputId}-hint`} className="text-xs text-muted-foreground">
+                  {cfg?.hasKey
+                    ? 'Ya hay una key guardada (cifrada). Dejá el campo vacío para conservarla, o pegá una nueva para reemplazarla.'
+                    : 'La key se guarda cifrada. No se vuelve a mostrar.'}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={modelInputId}>Modelo</Label>
+                <Input
+                  id={modelInputId}
+                  type="text"
+                  aria-describedby={`${modelInputId}-hint`}
+                  value={draft.model}
+                  onChange={(e) => setDraft(meta.provider, { model: e.target.value })}
+                  placeholder={meta.defaultModel}
+                  disabled={isSaving}
+                />
+                <p id={`${modelInputId}-hint`} className="text-xs text-muted-foreground">
+                  {meta.modelHint}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleTest(meta.provider)}
+                  disabled={isTesting || isSaving || !cfg?.hasKey}
+                >
+                  {isTesting ? (
+                    <>
+                      <Loader2 className="size-4 mr-2 animate-spin" />
+                      Probando...
+                    </>
+                  ) : (
+                    'Probar conexión'
+                  )}
+                </Button>
+                {!cfg?.hasKey && (
+                  <span className="text-xs text-muted-foreground">
+                    Guardá una key para poder probar la conexión.
+                  </span>
+                )}
+                {result && (
+                  <span
+                    className={`flex items-center gap-1 text-xs ${
+                      result.ok ? 'text-green-600' : 'text-destructive'
+                    }`}
+                    role="status"
+                  >
+                    {result.ok ? (
+                      <CheckCircle2 className="size-4" />
+                    ) : (
+                      <XCircle className="size-4" />
+                    )}
+                    {result.message}
+                  </span>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={isSaving}>
+          {isSaving ? (
+            <>
+              <Loader2 className="size-4 mr-2 animate-spin" />
+              Guardando...
+            </>
+          ) : (
+            'Guardar cambios'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/settings/features/parameters/components/SettingsView.tsx
+++ b/src/modules/settings/features/parameters/components/SettingsView.tsx
@@ -26,11 +26,13 @@ import { PdfSettingsForm } from '@/modules/settings/features/pdf/components/PdfS
 import { PdfEmailSettingsForm } from '@/modules/settings/features/pdf/components/PdfEmailSettingsForm';
 import RolesAndPermissionsSection from '@/modules/settings/features/roles/components/RolesAndPermissionsSection';
 import TaxesSection from '@/modules/settings/features/taxes/components/TaxesSection';
+import { getAiProviderConfigs } from '@/modules/settings/features/ai/actions.server';
+import { AiProviderSettingsForm } from '@/modules/settings/features/ai/components/AiProviderSettingsForm';
 import { can } from '@/shared/lib/permissions';
 import { getSession } from '@/shared/lib/session';
 import { prisma } from '@/shared/lib/prisma';
 
-const VALID_SECTIONS = ['employees', 'pdf', 'roles', 'taxes'] as const;
+const VALID_SECTIONS = ['employees', 'pdf', 'roles', 'taxes', 'ai'] as const;
 type Section = (typeof VALID_SECTIONS)[number];
 
 interface Props {
@@ -42,10 +44,18 @@ export default async function SettingsView({ currentSection }: Props) {
     ? (currentSection as Section)
     : 'employees';
 
-  const [canViewRoles, canManageTaxes] = await Promise.all([
+  const [canViewRoles, canManageTaxes, session] = await Promise.all([
     can('roles.view'),
     can('empresa.update'),
+    getSession(),
   ]);
+
+  const isPlatformAdmin = ['Admin', 'Super Admin', 'Developer'].includes(
+    session.profile?.role ?? ''
+  );
+  // La config de proveedores de IA es global: la administran el admin de
+  // plataforma o el dueño (owner) de la empresa activa.
+  const canManageAi = isPlatformAdmin || session.role === 'owner';
 
   return (
     <section className="space-y-4">
@@ -60,6 +70,7 @@ export default async function SettingsView({ currentSection }: Props) {
           <UrlTabsTrigger value="pdf">PDF</UrlTabsTrigger>
           {canManageTaxes && <UrlTabsTrigger value="taxes">Impuestos</UrlTabsTrigger>}
           {canViewRoles && <UrlTabsTrigger value="roles">Roles y permisos</UrlTabsTrigger>}
+          {canManageAi && <UrlTabsTrigger value="ai">IA / Proveedores</UrlTabsTrigger>}
         </UrlTabsList>
 
         <UrlTabsContent value="employees">
@@ -79,6 +90,12 @@ export default async function SettingsView({ currentSection }: Props) {
         {canViewRoles && (
           <UrlTabsContent value="roles">
             {section === 'roles' && <RolesAndPermissionsSection />}
+          </UrlTabsContent>
+        )}
+
+        {canManageAi && (
+          <UrlTabsContent value="ai">
+            {section === 'ai' && <AiSection />}
           </UrlTabsContent>
         )}
       </UrlTabs>
@@ -215,5 +232,23 @@ async function PdfSection() {
       <PdfSettingsForm initial={settings} />
       <PdfEmailSettingsForm initial={emailSettings} companyContactEmail={companyContactEmail} />
     </div>
+  );
+}
+
+async function AiSection() {
+  const configs = await getAiProviderConfigs();
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">Proveedores de IA</h2>
+        <p className="text-sm text-muted-foreground">
+          Configurá el motor de IA que se usa para leer las facturas de compra. La
+          API key se guarda cifrada y solo el proveedor activo se utiliza en la
+          extracción.
+        </p>
+      </div>
+      <AiProviderSettingsForm initial={configs} />
+    </section>
   );
 }

--- a/src/shared/lib/crypto.ts
+++ b/src/shared/lib/crypto.ts
@@ -1,0 +1,59 @@
+import 'server-only';
+
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // bytes (recomendado para GCM)
+
+/**
+ * Deriva una clave de 32 bytes a partir de ENCRYPTION_KEY usando SHA-256.
+ * Lanza un Error claro si la variable de entorno no está definida.
+ */
+function getKey(): Buffer {
+  const secret = process.env.ENCRYPTION_KEY;
+  if (!secret) {
+    throw new Error(
+      'ENCRYPTION_KEY no está definida en el entorno. Es requerida para cifrar/descifrar secretos.',
+    );
+  }
+  return crypto.createHash('sha256').update(secret).digest();
+}
+
+/**
+ * Cifra un texto plano con AES-256-GCM.
+ * Devuelve el string `${ivBase64}:${authTagBase64}:${ciphertextBase64}`.
+ */
+export function encryptSecret(plaintext: string): string {
+  const key = getKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('base64')}:${authTag.toString('base64')}:${ciphertext.toString('base64')}`;
+}
+
+/**
+ * Descifra un payload con formato `${ivBase64}:${authTagBase64}:${ciphertextBase64}`
+ * producido por encryptSecret. Devuelve el texto plano original.
+ */
+export function decryptSecret(payload: string): string {
+  const parts = payload.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Formato de secreto cifrado inválido. Se esperaba iv:tag:cipher en base64.');
+  }
+  const [ivBase64, authTagBase64, ciphertextBase64] = parts;
+  const key = getKey();
+  const iv = Buffer.from(ivBase64, 'base64');
+  const authTag = Buffer.from(authTagBase64, 'base64');
+  const ciphertext = Buffer.from(ciphertextBase64, 'base64');
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const plaintext = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+  return plaintext.toString('utf8');
+}

--- a/supabase/migrations/20260622150000_add_ai_provider_config.sql
+++ b/supabase/migrations/20260622150000_add_ai_provider_config.sql
@@ -1,0 +1,34 @@
+-- Configuración global de proveedores de IA para extracción de facturas.
+-- Tabla global (sin company_id), administrada solo por admin de plataforma.
+-- Exactamente una fila debe tener is_active = true (proveedor en uso).
+-- api_key se guarda CIFRADA con AES-256-GCM (formato iv:tag:cipher en base64).
+
+CREATE TABLE ai_provider_config (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider   TEXT        NOT NULL UNIQUE,            -- 'gemini' | 'openai'
+  api_key    TEXT,                                   -- cifrado (iv:tag:cipher base64); NULL si no configurada
+  model      TEXT,                                   -- ej 'gemini-2.5-flash' | 'gpt-4o-mini'
+  is_active  BOOLEAN     NOT NULL DEFAULT false,     -- exactamente UNA fila true = proveedor en uso
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed idempotente.
+-- NOTA: la fila 'gemini' trae un api_key cifrado de PRUEBA atado a la ENCRYPTION_KEY
+-- vigente al crear esta migración. Se reemplaza desde la UI (Settings > IA).
+-- Si la ENCRYPTION_KEY cambia, este valor dejará de descifrar (hay que recargar la key desde la UI).
+INSERT INTO ai_provider_config (provider, api_key, model, is_active)
+VALUES
+  (
+    'gemini',
+    'MTpGCrzAE4tGLG8c:hcRYFtaYyXc92dRnBOrdzQ==:hjQSxY4gpNa1PCNjoSm4BBkFfVOr4bn8/pipLH/MCvtnCemYWrM+lAusx0n9QgwkHh5PWtU=',
+    'gemini-2.5-flash',
+    true
+  ),
+  (
+    'openai',
+    NULL,
+    'gpt-4o-mini',
+    false
+  )
+ON CONFLICT (provider) DO NOTHING;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -93,6 +93,10 @@ const config = {
           from: { opacity: '0', transform: 'translateY(8px)' },
           to: { opacity: '1', transform: 'translateY(0)' },
         },
+        'indeterminate-progress': {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(400%)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
@@ -101,6 +105,7 @@ const config = {
         dash: 'dash 1.5s ease-in-out infinite',
         'fade-in': 'fade-in 0.3s ease-out',
         'fade-in-up': 'fade-in-up 0.4s ease-out',
+        'indeterminate-progress': 'indeterminate-progress 1.4s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Resumen
Sube un PDF/imagen de una factura de compra → un modelo de AI extrae los datos → pre-llena el formulario de carga de FAC para revisar y confirmar (nunca auto-guarda). Cierra tsk-9.

## Extracción
- `src/modules/purchasing/shared/invoice-extraction/`: adapter swappable (Gemini/OpenAI) por REST, schema Zod, mapeo a form, match de proveedor por CUIT (`suppliers.tax_id`).
- Server action `extractInvoiceDataFromFile`; UI `InvoiceAIUpload` integrada en `PurchaseInvoiceForm` con badges Extraído/Revisar, progreso indeterminado y flujo de "Crear proveedor" si el CUIT no existe.
- Reintento con backoff ante 503/429.

## Config de proveedores (Configuración → IA / Proveedores)
- Tabla global `ai_provider_config` + migración con seed; API keys **cifradas** (AES-256-GCM, `crypto.ts`, env `ENCRYPTION_KEY`).
- Selector de proveedor activo, carga de keys, modelo y "Probar conexión". Acceso: **owner de empresa o admin de plataforma**.
- El adapter lee la config de la DB (fallback a `GEMINI_API_KEY` de env).

## Config requerida en deploy
- `ENCRYPTION_KEY` (cifrado de las keys). `GEMINI_API_KEY` opcional como fallback.
- Aplicar la migración `20260622150000_add_ai_provider_config.sql` (`supabase db push`).

## Pruebas
- `npm run check-types` sin errores. Verificado en local: extracción end-to-end leyendo la config cifrada de la DB; gating de la tab; round-trip de cifrado.