### PR TITLE
fix(employees): tsk-337 baja de empleados no persistía por enum @map

### DIFF
--- a/src/modules/employees/features/create/actions.server.ts
+++ b/src/modules/employees/features/create/actions.server.ts
@@ -54,12 +54,18 @@ export const deactivateEmployee = async (documentNumber: string, terminationDate
     const { companyId } = await getActionContext();
     if (!companyId) throw new Error('No company selected');
 
+    // El cliente Prisma expone reason_for_termination_enum con los nombres de
+    // miembro (guion bajo: "Despido_sin_causa"), mientras que la UI envía el
+    // valor de DB con espacios ("Despido sin causa"). Normalizamos para que
+    // Prisma valide el enum correctamente; el @map lo persiste con espacios.
+    const normalizedReason = reason?.replaceAll(' ', '_');
+
     const data = await prisma.employees.updateMany({
       where: { document_number: documentNumber, company_id: companyId },
       data: {
         is_active: false,
         termination_date: new Date(terminationDate),
-        reason_for_termination: reason,
+        reason_for_termination: normalizedReason,
       } as any,
     });
 
@@ -180,7 +186,7 @@ export const deactivateEmployeeByDocNumber = async (
       data: {
         is_active: false,
         termination_date: terminationDate,
-        reason_for_termination: reason as any,
+        reason_for_termination: reason?.replaceAll(' ', '_') as any,
       },
     });
     return { error: null };

--- a/src/modules/employees/features/create/components/useEmployeeForm.ts
+++ b/src/modules/employees/features/create/components/useEmployeeForm.ts
@@ -404,7 +404,12 @@ export function useEmployeeFormLogic(user: any, guild: any, covenants: any, cate
     };
 
     try {
-      await deactivateEmployee(user.document_number, data.termination_date, data.reason_for_termination);
+      const result = await deactivateEmployee(user.document_number, data.termination_date, data.reason_for_termination);
+
+      if (result?.error) {
+        toast.error('Error al dar de baja al emplead@', { description: result.error });
+        return;
+      }
 
       setShowModal(!showModal);
       toast('Emplead@ eliminado', { description: `El emplead@ ${user.full_name} ha sido eliminado` });

--- a/src/modules/employees/features/list/components/EmployeeRowActions.tsx
+++ b/src/modules/employees/features/list/components/EmployeeRowActions.tsx
@@ -176,7 +176,13 @@ export function EmployeeRowActions({ row }: EmployeeRowActionsProps) {
     };
 
     try {
-      await deactivateEmployee(document, data.termination_date, data.reason_for_termination);
+      const result = await deactivateEmployee(document, data.termination_date, data.reason_for_termination);
+
+      if (result?.error) {
+        const message = await errorTranslate(result.error);
+        toast('Error al dar de baja al empleado', { description: message });
+        return;
+      }
 
       setShowModal(!showModal);
 

--- a/src/modules/employees/features/list/components/columns.tsx
+++ b/src/modules/employees/features/list/components/columns.tsx
@@ -195,7 +195,13 @@ export const EmployeesListColumns: ColumnDef<Colum>[] = [
           ?.map((e: any) => e.id);
 
         try {
-          await reactivateEmployeeByDocNumber(document);
+          const result = await reactivateEmployeeByDocNumber(document);
+
+          if (result?.error) {
+            const message = await errorTranslate(result.error);
+            toast('Error al reintegrar al empleado', { description: message });
+            return;
+          }
 
           if (documentToUpdate?.length) {
             await resetDocumentEmployeesForReintegration(documentToUpdate);
@@ -220,7 +226,13 @@ export const EmployeesListColumns: ColumnDef<Colum>[] = [
         };
 
         try {
-          await deactivateEmployee(document, data.termination_date, data.reason_for_termination);
+          const result = await deactivateEmployee(document, data.termination_date, data.reason_for_termination);
+
+          if (result?.error) {
+            const message = await errorTranslate(result.error);
+            toast('Error al dar de baja al empleado', { description: message });
+            return;
+          }
 
           setShowModal(!showModal);
 


### PR DESCRIPTION
Causa raíz: tras migrar de Supabase a Prisma, deactivateEmployee enviaba reason_for_termination con el valor de DB ("Despido sin causa", con espacios), pero el cliente Prisma valida el enum por nombre de miembro ("Despido_sin_causa"). Prisma lanzaba PrismaClientValidationError, la baja nunca se aplicaba y los callers no chequeaban result.error, mostrando un toast de éxito falso.

- Normaliza el motivo (espacios -> guion bajo) en deactivateEmployee y deactivateEmployeeByDocNumber antes del updateMany.
- Verifica result.error en columns.tsx (baja + reactivación), EmployeeRowActions.tsx y useEmployeeForm.ts.