### PR TITLE
fix(employees,equipment): tsk-364 edición de empleados y tsk-297 orde…

### DIFF
--- a/src/modules/employees/features/create/components/useEmployeeForm.ts
+++ b/src/modules/employees/features/create/components/useEmployeeForm.ts
@@ -31,6 +31,20 @@ import {
 import { Province } from '@/modules/employees/shared/types';
 import { getPersonalDataFields, getContactDataFields, getLaboralDataFields } from './fieldDefinitions';
 
+/**
+ * Resuelve el id de una opción (FK) a string para campos REQUERIDOS.
+ * Si la opción no se encontró (id null/undefined) devuelve `undefined` para que
+ * Prisma omita el campo, en lugar del string literal "undefined" que rompe la
+ * validación de tipos (BigInt/UUID) y aborta el update/create completo.
+ */
+const reqId = (id: unknown): string | undefined => (id == null ? undefined : String(id));
+
+/**
+ * Igual que `reqId` pero para campos OPCIONALES (nullable): devuelve `null`
+ * cuando la opción no se encontró, preservando la semántica de "sin valor".
+ */
+const optId = (id: unknown): string | null => (id == null ? null : String(id));
+
 export function useEmployeeFormLogic(user: any, guild: any, covenants: any, categories: any) {
   const actualCompany = useLoggedUserStore((state) => state.actualCompany);
   const searchParams = useSearchParams();
@@ -184,11 +198,11 @@ export function useEmployeeFormLogic(user: any, guild: any, covenants: any, cate
             values.born_date instanceof Date
               ? values.born_date.toISOString()
               : values.born_date,
-          province: String(provincesOptions.find((e: any) => e.name.trim() === values.province)?.id),
-          birthplace: String(countryOptions.find((e: any) => e.name === values.birthplace)?.id),
-          city: String(citysOptions.find((e: any) => e.name.trim() === values.city)?.id),
-          hierarchical_position: String(hierarchyOptions.find((e: any) => e.name === values.hierarchical_position)?.id),
-          workflow_diagram: String(workDiagramOptions.find((e: any) => e.name === values.workflow_diagram)?.id),
+          province: reqId(provincesOptions.find((e: any) => e.name.trim() === values.province)?.id),
+          birthplace: reqId(countryOptions.find((e: any) => e.name === values.birthplace)?.id),
+          city: reqId(citysOptions.find((e: any) => e.name.trim() === values.city)?.id),
+          hierarchical_position: optId(hierarchyOptions.find((e: any) => e.name === values.hierarchical_position)?.id),
+          workflow_diagram: optId(workDiagramOptions.find((e: any) => e.name === values.workflow_diagram)?.id),
           guild_id: values.guild_id || null,
           covenants_id: values.covenants_id || null,
           category_id: values.category_id || null,
@@ -200,7 +214,7 @@ export function useEmployeeFormLogic(user: any, guild: any, covenants: any, cate
         };
 
         try {
-          const applies = await createEmployee(finalValues);
+          const applies = await createEmployee(finalValues as any);
           const employeeId = applies?.[0]?.id ?? '';
 
           const { data: existingTypes } = await fetchExistingDocumentTypes(
@@ -295,11 +309,11 @@ export function useEmployeeFormLogic(user: any, guild: any, covenants: any, cate
             values.born_date instanceof Date
               ? values.born_date.toISOString()
               : values.born_date,
-          province: String(provincesOptions.find((e: any) => e.name.trim() === values.province)?.id),
-          birthplace: String(countryOptions.find((e: any) => e.name === values.birthplace)?.id),
-          city: String(citysOptions.find((e: any) => e.name.trim() === values.city)?.id),
-          hierarchical_position: String(hierarchyOptions.find((e: any) => e.name === values.hierarchical_position)?.id),
-          workflow_diagram: String(workDiagramOptions.find((e: any) => e.name === values.workflow_diagram)?.id),
+          province: reqId(provincesOptions.find((e: any) => e.name.trim() === values.province)?.id),
+          birthplace: reqId(countryOptions.find((e: any) => e.name === values.birthplace)?.id),
+          city: reqId(citysOptions.find((e: any) => e.name.trim() === values.city)?.id),
+          hierarchical_position: optId(hierarchyOptions.find((e: any) => e.name === values.hierarchical_position)?.id),
+          workflow_diagram: optId(workDiagramOptions.find((e: any) => e.name === values.workflow_diagram)?.id),
           guild_id: values.guild_id || null,
           covenants_id: values.covenants_id || null,
           category_id: values.category_id || null,
@@ -326,7 +340,7 @@ export function useEmployeeFormLogic(user: any, guild: any, covenants: any, cate
         }
 
         try {
-          await updateEmployee(finalValues, user?.id);
+          await updateEmployee(finalValues as any, user?.id);
           await handleUpload();
           router.refresh();
           router.push('/dashboard/employee');

--- a/src/modules/equipment/features/list/actions.server.ts
+++ b/src/modules/equipment/features/list/actions.server.ts
@@ -198,6 +198,29 @@ const equipmentFkTextFilters: Record<string, { relation: string; field: string }
 /** Search fields for global search */
 const equipmentSearchFields = ['domain', 'intern_number', 'chassis', 'engine', 'serie'];
 
+/**
+ * Columnas que son FK a una relación: ordenar por el id numérico de la FK no
+ * tiene sentido para el usuario, hay que ordenar por el `name` de la relación.
+ * Mapea el columnId del DataTable → path anidado de Prisma.
+ */
+const equipmentRelationOrderBy: Record<string, string> = {
+  brand: 'brand_rel',
+  model: 'model_rel',
+  type: 'type_rel',
+  types_of_vehicles: 'type_of_vehicle_rel',
+};
+
+/** Construye el `orderBy` de Prisma resolviendo columnas de relación a `{ rel: { name } }`. */
+function buildEquipmentOrderBy(
+  sortBy: string | null,
+  sortOrder: 'asc' | 'desc',
+): Record<string, unknown> {
+  if (!sortBy) return { domain: 'asc' };
+  const relation = equipmentRelationOrderBy[sortBy];
+  if (relation) return { [relation]: { name: sortOrder } };
+  return { [sortBy]: sortOrder };
+}
+
 type EquipmentPaginatedOptions = { showInactive?: boolean };
 
 /**
@@ -275,7 +298,8 @@ export async function getEquipmentPaginated(
 
   try {
     const state = parseSearchParams(searchParams);
-    const { skip, take, orderBy } = stateToPrismaParams(state);
+    const { skip, take } = stateToPrismaParams(state);
+    const orderBy = buildEquipmentOrderBy(state.sortBy, state.sortOrder);
 
     const where = buildEquipmentWhere(state, companyId, options?.showInactive);
 
@@ -285,7 +309,7 @@ export async function getEquipmentPaginated(
         include: equipmentPaginatedInclude,
         skip,
         take,
-        orderBy: orderBy ?? { domain: 'asc' },
+        orderBy,
       }),
       prisma.vehicles.count({ where }),
     ]);
@@ -303,7 +327,7 @@ export async function getEquipmentPaginated(
  */
 export async function getEquipmentFacets(
   showInactive?: boolean,
-): Promise<Record<string, { value: string; count: number }[]>> {
+): Promise<Record<string, { value: string; count: number; label?: string }[]>> {
   const { companyId } = await getActionContext();
   if (!companyId) return {};
 
@@ -328,12 +352,15 @@ export async function getEquipmentFacets(
       groupByField('condition'),
     ]);
 
-    // Helper to convert groupBy result to facet array
+    // Helper to convert groupBy result to facet array.
+    // `value` es el nombre de miembro del enum Prisma (con guion bajo, ej. "No_avalado");
+    // `label` es el texto legible que ve el usuario en el dropdown (ej. "No avalado").
     const toFacetArray = (counts: any[], field: string) =>
       counts
         .filter((item) => item[field] != null && item[field] !== '')
         .map((item) => ({
           value: String(item[field]),
+          label: String(item[field]).replaceAll('_', ' '),
           count: item._count?._all ?? item._count ?? 0,
         }));
 
@@ -362,10 +389,8 @@ export async function getAllEquipmentForExport(
     const state = parseSearchParams(searchParams);
     const where = buildEquipmentWhere(state, companyId, options?.showInactive);
 
-    // Use orderBy from state if provided, otherwise default
-    const orderBy = state.sortBy
-      ? { [state.sortBy]: state.sortOrder }
-      : { domain: 'asc' as const };
+    // Resuelve columnas de relación a `{ rel: { name } }` igual que la query paginada
+    const orderBy = buildEquipmentOrderBy(state.sortBy, state.sortOrder);
 
     const data = await prisma.vehicles.findMany({
       where,

--- a/src/modules/equipment/features/list/components/_EquipmentDataTable.tsx
+++ b/src/modules/equipment/features/list/components/_EquipmentDataTable.tsx
@@ -9,7 +9,7 @@ import {
 import { equipmentColumns } from './equipment-columns';
 import { getEquipmentFacets, getAllEquipmentForExport } from '../actions.server';
 
-interface FacetEntry { value: string; count: number }
+interface FacetEntry { value: string; count: number; label?: string }
 
 interface Props {
   data: any[];
@@ -42,7 +42,7 @@ export function _EquipmentDataTable({ data, totalRows, searchParams }: Props) {
   const buildFacetConfig = (entries: FacetEntry[] | undefined) => {
     if (!entries || entries.length === 0) return { options: [], externalCounts: new Map<string, number>() };
     return {
-      options: entries.map((e) => ({ value: e.value, label: e.value })),
+      options: entries.map((e) => ({ value: e.value, label: e.label ?? e.value })),
       externalCounts: new Map(entries.map((e) => [e.value, e.count])),
     };
   };

--- a/src/modules/equipment/features/list/components/equipment-columns.tsx
+++ b/src/modules/equipment/features/list/components/equipment-columns.tsx
@@ -96,8 +96,9 @@ export const equipmentColumns: ColumnDef<any>[] = [
   {
     accessorKey: 'type',
     meta: { title: 'Tipo' },
-    header: 'Tipo',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Tipo" />,
     cell: ({ row }) => <Badge>{row.original.type_rel?.name}</Badge>,
+    enableSorting: true,
     filterFn: (row, columnId, filterValue) => {
       return (
         row.original.type_rel?.name?.toLowerCase()?.includes(filterValue.toLowerCase()) ?? false
@@ -107,8 +108,9 @@ export const equipmentColumns: ColumnDef<any>[] = [
   {
     accessorKey: 'types_of_vehicles',
     meta: { title: 'Tipo de vehiculo' },
-    header: 'Tipo de vehiculo',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Tipo de vehiculo" />,
     cell: ({ row }) => <Badge>{row.original.type_of_vehicle_rel?.name as string}</Badge>,
+    enableSorting: true,
   },
   {
     accessorKey: 'engine',
@@ -179,8 +181,9 @@ export const equipmentColumns: ColumnDef<any>[] = [
   {
     accessorKey: 'brand',
     meta: { title: 'Marca' },
-    header: 'Marca',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Marca" />,
     cell: ({ row }) => <div>{row.original.brand_rel?.name}</div>,
+    enableSorting: true,
     filterFn: (row, columnId, filterValue) => {
       return (
         row.original?.brand_rel?.name?.toLowerCase()?.includes(filterValue.toLowerCase()) ?? false
@@ -196,8 +199,9 @@ export const equipmentColumns: ColumnDef<any>[] = [
   {
     accessorKey: 'model',
     meta: { title: 'Modelo' },
-    header: 'Modelo',
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Modelo" />,
     cell: ({ row }) => <div>{row.original.model_rel?.name}</div>,
+    enableSorting: true,
     filterFn: (row, columnId, filterValue) => {
       return (
         row.original.model_rel?.name?.toLowerCase().includes(filterValue.toLowerCase()) ?? false


### PR DESCRIPTION
…n/filtros de equipos

tsk-364: la edición no persistía porque String(lookup?.id) generaba el string literal "undefined" cuando el campo no resolvía (todos los empleados sin hierarchical_position/workflow_diagram), y Prisma aborta el update al recibir "undefined" en columnas UUID/BigInt. Helpers reqId/optId mapean a undefined/null en onCreate y onUpdate.

tsk-297: columnas de relación (Marca, Modelo, Tipo, Tipo de vehículo) ahora son ordenables y ordenan por nombre vía buildEquipmentOrderBy (brand -> brand_rel.name) en listado y export, en vez de por el id de la FK. Dropdowns de Estado/Condición muestran texto legible (label sin guion bajo) en lugar del nombre de miembro del enum.