### PR TITLE
fix(data-table): respuesta inmediata de filtros con check optimista +…

### DIFF
--- a/src/shared/components/common/DataTable/DataTable.tsx
+++ b/src/shared/components/common/DataTable/DataTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { Loader2 } from 'lucide-react';
 import {
   flexRender,
   getCoreRowModel,
@@ -114,6 +115,7 @@ export function DataTable<TData extends Record<string, unknown>, TValue = unknow
     onPaginationChange,
     onSortingChange,
     onColumnFiltersChange,
+    isPending,
   } = useDataTable({
     filterableColumns,
   });
@@ -199,8 +201,15 @@ export function DataTable<TData extends Record<string, unknown>, TValue = unknow
       />
 
       {/* Table */}
-      <div className="overflow-hidden rounded-md border">
-        <Table>
+      <div className="relative overflow-hidden rounded-md border">
+        {isPending && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px]">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        <Table
+          className={isPending ? 'pointer-events-none opacity-60 transition-opacity' : 'transition-opacity'}
+        >
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/src/shared/components/common/DataTable/DataTableFacetedFilter.tsx
+++ b/src/shared/components/common/DataTable/DataTableFacetedFilter.tsx
@@ -31,8 +31,24 @@ export function DataTableFacetedFilter<TData, TValue>({
   externalCounts,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const facets = externalCounts ?? column?.getFacetedUniqueValues();
-  const selectedValues = new Set(column?.getFilterValue() as string[]);
   const [search, setSearch] = React.useState('');
+
+  // Estado optimista: el checkbox reacciona al instante al clickear, sin esperar
+  // el round-trip al servidor (el filtro real viaja por la URL). Se re-sincroniza
+  // cuando el servidor confirma el cambio y la URL/columna se actualiza.
+  const urlValue = (column?.getFilterValue() as string[] | undefined) ?? [];
+  const urlKey = urlValue.join(',');
+  const [optimisticValues, setOptimisticValues] = React.useState<string[]>(urlValue);
+  React.useEffect(() => {
+    setOptimisticValues(urlValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlKey]);
+  const selectedValues = new Set(optimisticValues);
+
+  const applySelection = (values: string[]) => {
+    setOptimisticValues(values);
+    column?.setFilterValue(values.length ? values : undefined);
+  };
 
   // Filter options: by externalCounts (if provided) and by local search
   const visibleOptions = React.useMemo(() => {
@@ -115,15 +131,13 @@ export function DataTableFacetedFilter<TData, TValue>({
                     key={option.value}
                     value={option.value}
                     onSelect={() => {
+                      const next = new Set(selectedValues);
                       if (isSelected) {
-                        selectedValues.delete(option.value);
+                        next.delete(option.value);
                       } else {
-                        selectedValues.add(option.value);
+                        next.add(option.value);
                       }
-                      const filterValues = Array.from(selectedValues);
-                      column?.setFilterValue(
-                        filterValues.length ? filterValues : undefined
-                      );
+                      applySelection(Array.from(next));
                     }}
                     data-testid={`filter-option-${option.value}`}
                   >
@@ -156,7 +170,7 @@ export function DataTableFacetedFilter<TData, TValue>({
                 <CommandGroup>
                   <CommandItem
                     value="__clear__"
-                    onSelect={() => column?.setFilterValue(undefined)}
+                    onSelect={() => applySelection([])}
                     className="justify-center text-center"
                     data-testid={`filter-clear-${column?.id}`}
                   >

--- a/src/shared/components/common/DataTable/useDataTable.ts
+++ b/src/shared/components/common/DataTable/useDataTable.ts
@@ -2,7 +2,7 @@
 
 import type { ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useTransition } from 'react';
 
 import { DEFAULT_PAGE_SIZE, parseSearchParams, stateToSearchParams } from './helpers';
 import type { DataTableSearchParams, DataTableState } from './types';
@@ -59,6 +59,8 @@ interface UseDataTableReturn {
   onGlobalFilterChange: (value: string) => void;
   /** Resetear todos los filtros */
   resetFilters: () => void;
+  /** `true` mientras la navegación (sort/filtro/paginación) se está procesando en el servidor */
+  isPending: boolean;
 }
 
 /**
@@ -101,6 +103,7 @@ export function useDataTable(options: UseDataTableOptions = {}): UseDataTableRet
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   // Parsear estado actual de la URL
   const state = useMemo(() => {
@@ -154,8 +157,11 @@ export function useDataTable(options: UseDataTableOptions = {}): UseDataTableRet
       const merged = { ...state, ...newState };
       const params = stateToSearchParams(merged);
       const queryString = params.toString();
-      router.push(queryString ? `${pathname}?${queryString}` : pathname, {
-        scroll: false,
+      // Transición: la navegación no bloquea la UI y exponemos `isPending` para el loader.
+      startTransition(() => {
+        router.push(queryString ? `${pathname}?${queryString}` : pathname, {
+          scroll: false,
+        });
       });
     },
     [state, pathname, router]
@@ -243,7 +249,9 @@ export function useDataTable(options: UseDataTableOptions = {}): UseDataTableRet
       if (value) newParams.set(key, value);
     });
     const queryString = newParams.toString();
-    router.push(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+    startTransition(() => {
+      router.push(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+    });
   }, [pathname, router, searchParams, preserveParams]);
 
   return {
@@ -256,5 +264,6 @@ export function useDataTable(options: UseDataTableOptions = {}): UseDataTableRet
     onColumnFiltersChange,
     onGlobalFilterChange,
     resetFilters,
+    isPending,
   };
 }


### PR DESCRIPTION
… loader

El DataTable server-side dependía de la URL para reflejar la selección de los filtros faceted, así que el checkbox no reaccionaba hasta que volvía la respuesta del servidor (se sentía trabado).

- Check optimista: el filtro faceted marca/desmarca al instante con estado local y se re-sincroniza cuando el servidor confirma (sin parpadeo).
- useTransition en la navegación (sort/filtro/paginación) + overlay con spinner y tabla atenuada mientras isPending, para comunicar el "procesando".

Mejora compartida: aplica a Equipos y Empleados.