### PR TITLE
feat(maintenance): tsk-380 bloquear pedido de reparación duplicado de…

### DIFF
--- a/src/app/api/repair_solicitud/route.ts
+++ b/src/app/api/repair_solicitud/route.ts
@@ -1,7 +1,11 @@
 import { prisma } from '@/shared/lib/prisma';
 import { apiSuccess, apiError } from '@/shared/lib/api-response';
 import { serializeBigInt } from '@/shared/lib/utils';
-import { recalculateVehicleCondition } from '@/modules/maintenance/features/repairs/actions.server';
+import {
+  recalculateVehicleCondition,
+  findConflictingOpenRepairs,
+} from '@/modules/maintenance/features/repairs/actions.server';
+import { buildRepairConflictMessage } from '@/modules/maintenance/features/repairs/repairRules';
 import { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -75,6 +79,40 @@ export async function POST(request: NextRequest) {
   const body = await request.json();
 
   try {
+    // --- Guard: no permitir un pedido de reparación si la unidad ya tiene uno
+    // del mismo tipo sin resolver (tarea 380). Aplica a todos los puntos de carga
+    // porque todos pasan por este endpoint. ---
+    const items: any[] = Array.isArray(body) ? body : [body];
+    const pairs = items
+      .filter((it) => it?.equipment_id && it?.reparation_type)
+      .map((it) => ({ equipment_id: it.equipment_id as string, reparation_type: it.reparation_type as string }));
+
+    // 1. Duplicados dentro del mismo payload (mismo equipo + tipo repetido).
+    const seen = new Set<string>();
+    for (const p of pairs) {
+      const key = `${p.equipment_id}::${p.reparation_type}`;
+      if (seen.has(key)) {
+        return apiError(
+          'No es posible crear la solicitud: cargaste dos veces el mismo tipo de reparación para la misma unidad.',
+          409,
+        );
+      }
+      seen.add(key);
+    }
+
+    // 2. Conflictos con solicitudes abiertas ya existentes en la base.
+    const conflicts = await findConflictingOpenRepairs(pairs);
+    if (conflicts.length > 0) {
+      const message = buildRepairConflictMessage(
+        conflicts.map((c: any) => ({
+          unit: c.equipment?.domain || c.equipment?.serie || 'sin dominio',
+          typeName: c.reparation_type_rel?.name ?? 'desconocido',
+          state: c.state,
+        })),
+      );
+      return apiError(message, 409);
+    }
+
     if (Array.isArray(body)) {
       const result = await prisma.repair_solicitudes.createMany({ data: body });
 

--- a/src/modules/maintenance/features/repairs/actions.server.ts
+++ b/src/modules/maintenance/features/repairs/actions.server.ts
@@ -9,6 +9,7 @@ import {
   buildTextFiltersWhere,
   buildDateRangeFiltersWhere,
 } from '@/shared/components/common/DataTable/helpers';
+import { RESOLVED_STATES } from './repairRules';
 
 // Repair-related queries
 
@@ -95,7 +96,7 @@ export const fetchOpenRepairsByEquipmentIdsAndType = async (
       where: {
         equipment_id: { in: equipmentIds },
         reparation_type: reparationTypeId,
-        state: { notIn: ['Cancelado', 'Finalizado', 'Rechazado'] },
+        state: { notIn: [...RESOLVED_STATES] },
       },
       include: { equipment: true },
     });
@@ -115,12 +116,45 @@ export const fetchOpenRepairsByEquipmentAndType = async (
       where: {
         equipment_id: equipmentId,
         reparation_type: reparationTypeId,
-        state: { notIn: ['Cancelado', 'Finalizado', 'Rechazado'] },
+        state: { notIn: [...RESOLVED_STATES] },
       },
     });
     return data;
   } catch (error) {
     console.error('Error fetching open repairs:', error);
+    return [];
+  }
+};
+
+/**
+ * Dado un conjunto de pares (equipo, tipo de reparación), devuelve las
+ * solicitudes ABIERTAS (no resueltas) que coinciden, incluyendo dominio/serie
+ * de la unidad y el nombre del tipo, para construir el mensaje de conflicto.
+ *
+ * Es la fuente de verdad del guard de duplicados del API (cubre todos los
+ * puntos de carga y llamadas directas al endpoint).
+ */
+export const findConflictingOpenRepairs = async (
+  pairs: { equipment_id: string; reparation_type: string }[]
+) => {
+  if (!pairs.length) return [];
+  try {
+    const data = await prisma.repair_solicitudes.findMany({
+      where: {
+        state: { notIn: [...RESOLVED_STATES] },
+        OR: pairs.map((p) => ({
+          equipment_id: p.equipment_id,
+          reparation_type: p.reparation_type,
+        })),
+      },
+      include: {
+        equipment: { select: { domain: true, serie: true } },
+        reparation_type_rel: { select: { name: true } },
+      },
+    });
+    return data;
+  } catch (error) {
+    console.error('Error finding conflicting open repairs:', error);
     return [];
   }
 };

--- a/src/modules/maintenance/features/repairs/components/RepairEntry.tsx
+++ b/src/modules/maintenance/features/repairs/components/RepairEntry.tsx
@@ -8,6 +8,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { storage } from '@/shared/lib/storage';
 import { updateVehicleById } from '@/modules/equipment/features/create/actions.server';
 import { fetchOpenRepairsByEquipmentAndType } from '@/modules/maintenance/features/repairs/actions.server';
+import { buildRepairConflictMessage } from '@/modules/maintenance/features/repairs/repairRules';
 import { cn } from '@/shared/lib/utils';
 
 import { formatDocumentTypeName, setVehiclesToShow } from '@/shared/lib/utils/utils';
@@ -122,20 +123,23 @@ export default function RepairNewEntry({
     );
 
     if (vehicle_id?.id) {
-      //Primero verificar el array de reparaciones
+      const unit = vehicle_id.domain || vehicle_id.serie || 'sin dominio';
+      const typeName = tipo_de_mantenimiento.find((t) => t.id === repairTypeId)?.name ?? 'desconocido';
+
+      //Primero verificar el array de reparaciones (en la carga actual)
       const hasOpenRepair = allRepairs.some((e) => e.repair === repairTypeId);
       if (hasOpenRepair) {
         toast.error(
-          'Ya existe una solicitud de reparacion con los mismos datos en estado pendiente para este vehiculo'
+          `No es posible agregar la solicitud: la unidad ${unit} ya tiene una solicitud del tipo "${typeName}" en esta carga.`
         );
         return true;
       }
 
       const repair_solicitudes = await fetchOpenRepairsByEquipmentAndType(vehicle_id?.id, repairTypeId);
 
-      if (repair_solicitudes?.length ?? 0 > 0) {
+      if ((repair_solicitudes?.length ?? 0) > 0) {
         toast.error(
-          `Ya existe una solicitud de reparacion con los mismos datos en estado ${repair_solicitudes?.[0].state} para este vehiculo`
+          buildRepairConflictMessage([{ unit, typeName, state: String(repair_solicitudes?.[0].state) }])
         );
         return true; // Indica que se encontró una solicitud abierta
       }
@@ -282,12 +286,13 @@ export default function RepairNewEntry({
           }
         } catch (error) {
           console.error(error);
+          throw error;
         }
       },
       {
-        loading: 'Creando tipo de reparación...',
-        success: 'Tipo de reparación creado con éxito',
-        error: 'Hubo un error al crear el tipo de reparación',
+        loading: 'Creando solicitud de reparación...',
+        success: 'Solicitud de reparación creada con éxito',
+        error: (err) => (err instanceof Error ? err.message : 'Hubo un error al crear la solicitud'),
       }
     );
   };

--- a/src/modules/maintenance/features/repairs/components/RepairEntryMultiple.tsx
+++ b/src/modules/maintenance/features/repairs/components/RepairEntryMultiple.tsx
@@ -7,6 +7,7 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/shar
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/table';
 import { updateVehicleById } from '@/modules/equipment/features/create/actions.server';
 import { fetchOpenRepairsByEquipmentIdsAndType } from '@/modules/maintenance/features/repairs/actions.server';
+import { buildRepairConflictMessage } from '@/modules/maintenance/features/repairs/repairRules';
 import { cn } from '@/shared/lib/utils';
 
 import { setVehiclesToShow } from '@/shared/lib/utils/utils';
@@ -93,12 +94,12 @@ export default function RepairNewEntryMultiple({
     );
 
     const hasOpenRepair = allRepairs.filter((e) => domainsOrSeries.includes(e.domain) && e.repair === repairTypeId);
+    const typeName = tipo_de_mantenimiento.find((t) => t.id === repairTypeId)?.name ?? 'desconocido';
 
     if (hasOpenRepair.length > 0) {
+      const units = hasOpenRepair.map((e) => e.domain).join(', ');
       toast.error(
-        `Los equipos con los siguientes dominios o series ya tienen una solicitud de reparacion a ser registrada ${hasOpenRepair
-          .map((e) => e.domain)
-          .join(', ')}`
+        `No es posible agregar la solicitud: las unidades ${units} ya tienen una solicitud del tipo "${typeName}" en esta carga.`
       );
       return true;
     }
@@ -106,10 +107,15 @@ export default function RepairNewEntryMultiple({
     //Consultar en la base de datos si ya existe una solicitud de reparacion abierta para alguno de los vehiculos
     const data = await fetchOpenRepairsByEquipmentIdsAndType(vehiclesIds, repairTypeId);
 
-    if (data?.length ?? 0 > 0) {
+    if ((data?.length ?? 0) > 0) {
       toast.error(
-        `
-        El equipo con dominio o serie "${(data?.[0].equipment_id as any).domain || (data?.[0].equipment_id as any).serie}" ya tiene una solicitud de reparacion con los mismos datos en estado ${data?.[0].state}`
+        buildRepairConflictMessage(
+          (data ?? []).map((d: any) => ({
+            unit: d.equipment?.domain || d.equipment?.serie || 'sin dominio',
+            typeName,
+            state: String(d.state),
+          }))
+        )
       );
       return true; // Indica que se encontró una solicitud abierta
     }
@@ -215,12 +221,13 @@ export default function RepairNewEntryMultiple({
           }
         } catch (error) {
           console.error(error);
+          throw error;
         }
       },
       {
-        loading: 'Creando tipo de reparación...',
-        success: 'Tipo de reparación creado con éxito',
-        error: 'Hubo un error al crear el tipo de reparación',
+        loading: 'Creando solicitud de reparación...',
+        success: 'Solicitud de reparación creada con éxito',
+        error: (err) => (err instanceof Error ? err.message : 'Hubo un error al crear la solicitud'),
       }
     );
   };

--- a/src/modules/maintenance/features/repairs/repairRules.ts
+++ b/src/modules/maintenance/features/repairs/repairRules.ts
@@ -1,0 +1,52 @@
+/**
+ * Reglas compartidas de pedidos de reparación (repair_solicitudes).
+ *
+ * Módulo PURO (sin 'use server' ni imports de servidor): lo usan tanto el guard
+ * del API como los formularios cliente, para no duplicar la definición de
+ * "estado resuelto" ni el formato del mensaje de conflicto.
+ */
+
+/**
+ * Estados que se consideran RESUELTOS (cerrados). Cualquier otro estado
+ * (Pendiente, Esperando_repuestos, En_reparacion, Programado) cuenta como
+ * "no resuelto" / abierto a efectos de la regla de duplicados.
+ */
+export const RESOLVED_STATES = ['Cancelado', 'Finalizado', 'Rechazado'] as const;
+
+/** Etiquetas legibles de los estados abiertos para mostrar al usuario. */
+const STATE_LABELS: Record<string, string> = {
+  Pendiente: 'pendiente',
+  Esperando_repuestos: 'esperando repuestos',
+  En_reparacion: 'en reparación',
+  Programado: 'programada',
+};
+
+/** Convierte el nombre de miembro del enum a texto legible (fallback genérico). */
+export function formatRepairState(state: string): string {
+  return STATE_LABELS[state] ?? state.replaceAll('_', ' ').toLowerCase();
+}
+
+export interface RepairConflict {
+  /** Dominio o serie de la unidad. */
+  unit: string;
+  /** Nombre del tipo de reparación. */
+  typeName: string;
+  /** Estado (nombre de miembro del enum) de la solicitud en conflicto. */
+  state: string;
+}
+
+/**
+ * Arma el mensaje de error claro para mostrar en el toast cuando ya existe una
+ * solicitud del mismo tipo sin resolver para la unidad.
+ */
+export function buildRepairConflictMessage(conflicts: RepairConflict[]): string {
+  if (conflicts.length === 0) return '';
+
+  if (conflicts.length === 1) {
+    const c = conflicts[0];
+    return `No es posible crear la solicitud: la unidad ${c.unit} ya tiene una solicitud del tipo "${c.typeName}" en estado ${formatRepairState(c.state)}.`;
+  }
+
+  const list = conflicts.map((c) => `${c.unit} (${c.typeName})`).join(', ');
+  return `No es posible crear la solicitud: las siguientes unidades ya tienen una solicitud sin resolver del mismo tipo: ${list}.`;
+}


### PR DESCRIPTION
…l mismo tipo

No se permite cargar un pedido de reparación si la unidad ya tiene uno del mismo tipo en estado no resuelto (Pendiente/Esperando repuestos/En reparación/Programado).

- repairRules.ts (nuevo): RESOLVED_STATES + buildRepairConflictMessage, fuente única del criterio y del mensaje, compartida por API y formularios.
- findConflictingOpenRepairs en actions.server.ts; los checks existentes usan RESOLVED_STATES.
- Guard autoritativo en POST /api/repair_solicitud: dedupe del payload + chequeo en BD -> 409 con mensaje claro antes de insertar. Cubre todos los puntos de carga.
- RepairEntry/RepairEntryMultiple: toasts unificados con el mensaje claro. Fix de bugs latentes: catch que se tragaba el error (mostraba éxito falso), precedencia `?? 0 > 0` y acceso a equipment_id.domain inexistente.