### PR TITLE
feat(documentos): filtro de tipo de documento por opciones (TKT 443)

### DIFF
--- a/src/modules/documents/features/list/actions.server.ts
+++ b/src/modules/documents/features/list/actions.server.ts
@@ -960,10 +960,11 @@ function buildEmployeeDocumentsWhere(
     }
   }
 
-  // 5. Filter by documentName (name on document_type relation — substring match)
+  // 5. Filter by documentName (name on document_type relation — exact match por opciones)
   const docNameFilter = state.filters.documentName;
   if (docNameFilter?.length) {
-    (baseWhere.document_type as any).is.name = { contains: docNameFilter[0], mode: 'insensitive' };
+    (baseWhere.document_type as any).is.name =
+      docNameFilter.length === 1 ? docNameFilter[0] : { in: docNameFilter };
   }
 
   // 6. Filter by resource (employee lastname + firstname — substring match)
@@ -1271,10 +1272,11 @@ function buildEquipmentDocumentsWhere(
     }
   }
 
-  // Filter by documentName (name on document_type relation — substring match)
+  // Filter by documentName (name on document_type relation — exact match por opciones)
   const docNameFilter = state.filters.documentName;
   if (docNameFilter?.length) {
-    (baseWhere.document_type as any).is.name = { contains: docNameFilter[0], mode: 'insensitive' };
+    (baseWhere.document_type as any).is.name =
+      docNameFilter.length === 1 ? docNameFilter[0] : { in: docNameFilter };
   }
 
   // Filter by resource (vehicle domain — substring match)

--- a/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
+++ b/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
@@ -26,7 +26,7 @@ const FILTER_DEFINITIONS: { columnId: string; title: string; type: 'faceted' | '
   { columnId: 'state', title: 'Estado', type: 'faceted' },
   { columnId: 'mandatory', title: 'Obligatorio', type: 'faceted' },
   { columnId: 'resource', title: 'Empleado', type: 'text' },
-  { columnId: 'documentName', title: 'Documento', type: 'text' },
+  { columnId: 'documentName', title: 'Documento', type: 'faceted' },
   { columnId: 'allocated_to', title: 'Afectado a', type: 'text' },
   { columnId: 'validity', title: 'Vencimiento', type: 'dateRange' },
 ];

--- a/src/modules/documents/features/list/components/_EquipmentDocumentDataTable.tsx
+++ b/src/modules/documents/features/list/components/_EquipmentDocumentDataTable.tsx
@@ -25,7 +25,7 @@ const FILTER_DEFINITIONS: { columnId: string; title: string; type: 'faceted' | '
   { columnId: 'state', title: 'Estado', type: 'faceted' },
   { columnId: 'mandatory', title: 'Obligatorio', type: 'faceted' },
   { columnId: 'resource', title: 'Equipo (Dominio)', type: 'text' },
-  { columnId: 'documentName', title: 'Documento', type: 'text' },
+  { columnId: 'documentName', title: 'Documento', type: 'faceted' },
   { columnId: 'allocated_to', title: 'Tipo de vehiculo', type: 'text' },
   { columnId: 'validity', title: 'Vencimiento', type: 'dateRange' },
 ];


### PR DESCRIPTION
El filtro "Documento" en las tablas de documentación de empleados y equipos pasa de texto libre a un selector por opciones (multi-select) con los tipos disponibles y su conteo.

- Data tables: documentName de type 'text' a 'faceted' (opciones y conteos ya provistos por los facets del servidor)
- actions.server: where de documentName de contains a match exacto / { in: [...] }, siguiendo el patrón del filtro state