### PR TITLE
perf(waterfall): reducir server-actions secuenciales en carga (facets…

### DIFF
--- a/src/modules/documents/features/list/components/EmployeeDocumentList.tsx
+++ b/src/modules/documents/features/list/components/EmployeeDocumentList.tsx
@@ -1,4 +1,7 @@
-import { getEmployeeDocumentsPaginated } from '@/modules/documents/features/list/actions.server';
+import {
+  getEmployeeDocumentsPaginated,
+  getEmployeeDocumentFacets,
+} from '@/modules/documents/features/list/actions.server';
 import { _EmployeeDocumentDataTable } from './_EmployeeDocumentDataTable';
 import type { DataTableSearchParams } from '@/shared/components/data-table';
 
@@ -9,12 +12,19 @@ interface Props {
 }
 
 export async function EmployeeDocumentList({ searchParams, monthly, downDocument }: Props) {
-  const { data, total } = await getEmployeeDocumentsPaginated(searchParams, { monthly, downDocument });
+  // Facets se fetchean en el servidor (en paralelo con los datos) y se pasan como prop:
+  // antes se cargaban con un useEffect cliente, generando un server-action POST secuencial
+  // por tabla (Next serializa los server actions → waterfall). Ahora es 1 render RSC.
+  const [{ data, total }, facets] = await Promise.all([
+    getEmployeeDocumentsPaginated(searchParams, { monthly, downDocument }),
+    getEmployeeDocumentFacets({ monthly, downDocument }),
+  ]);
 
   return (
     <_EmployeeDocumentDataTable
       data={data}
       totalRows={total}
+      facets={facets}
       searchParams={searchParams}
       monthly={monthly}
       downDocument={downDocument}

--- a/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
+++ b/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   DataTable,
   type DataTableFacetedFilterConfig,
   type DataTableSearchParams,
 } from '@/shared/components/data-table';
 import { permanentDocumentColumns, monthlyDocumentColumns } from './document-columns';
-import { getEmployeeDocumentFacets, getAllEmployeeDocumentsForExport } from '../actions.server';
+import { getAllEmployeeDocumentsForExport } from '../actions.server';
 
 interface FacetEntry {
   value: string;
@@ -17,6 +17,8 @@ interface FacetEntry {
 interface Props {
   data: any[];
   totalRows: number;
+  /** Facets pre-calculados en el servidor (evita el server-action POST en cliente). */
+  facets: Record<string, FacetEntry[]>;
   searchParams: DataTableSearchParams;
   monthly?: boolean;
   downDocument?: boolean;
@@ -33,18 +35,13 @@ const FILTER_DEFINITIONS: { columnId: string; title: string; type: 'faceted' | '
 
 const DEFAULT_VISIBLE_FILTERS = new Set(['state', 'resource', 'documentName']);
 
-export function _EmployeeDocumentDataTable({ data, totalRows, searchParams, monthly, downDocument }: Props) {
-  const [facets, setFacets] = useState<Record<string, FacetEntry[]> | null>(null);
+export function _EmployeeDocumentDataTable({ data, totalRows, facets, searchParams, monthly, downDocument }: Props) {
   const columns = monthly ? monthlyDocumentColumns : permanentDocumentColumns;
   const tableId = downDocument
     ? 'employee-docs-baja'
     : monthly
       ? 'employee-docs-monthly'
       : 'employee-docs-permanent';
-
-  useEffect(() => {
-    getEmployeeDocumentFacets({ monthly, downDocument }).then(setFacets).catch(console.error);
-  }, [monthly, downDocument]);
 
   const buildFacetConfig = (entries: FacetEntry[] | undefined) => {
     if (!entries || entries.length === 0) return { options: [], externalCounts: new Map<string, number>() };

--- a/src/shared/actions/notifications.ts
+++ b/src/shared/actions/notifications.ts
@@ -21,6 +21,20 @@ export async function getMyUnreadCount(companyId?: string) {
   return unreadNotificationsCountForCurrentUser(companyId);
 }
 
+/**
+ * Lista + contador de no leídos en un solo server action. Next serializa los
+ * server actions, así que llamar getMyNotifications y getMyUnreadCount por
+ * separado desde el cliente genera 2 POST secuenciales; esto los une en 1
+ * (Promise.all server-side). Se usa en el badge del NavBar, presente en toda página.
+ */
+export async function getMyNotificationsWithCount(companyId?: string, onlyUnread = false) {
+  const [list, count] = await Promise.all([
+    listNotificationsForCurrentUser({ companyId, onlyUnread }),
+    unreadNotificationsCountForCurrentUser(companyId),
+  ]);
+  return { list, count };
+}
+
 export async function markAsRead(notificationId: string) {
   return markNotificationAsRead(notificationId);
 }

--- a/src/shared/components/data-table/DataTable.tsx
+++ b/src/shared/components/data-table/DataTable.tsx
@@ -194,9 +194,16 @@ function DataTableServerSide<TData extends Record<string, unknown>, TValue = unk
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
-  // Persist column visibility with debounce
+  // Persist column visibility with debounce. Se omite el primer run (montaje):
+  // antes disparaba un server-action POST de escritura en CADA carga de tabla, sin
+  // que el usuario hubiese cambiado nada, sumándose al waterfall de server actions.
+  const skipFirstVisibilitySave = React.useRef(true);
   React.useEffect(() => {
     if (!tableId) return;
+    if (skipFirstVisibilitySave.current) {
+      skipFirstVisibilitySave.current = false;
+      return;
+    }
 
     const timer = setTimeout(() => {
       saveTableColumnVisibility(tableId, columnVisibility);
@@ -325,9 +332,15 @@ function DataTableClientSide<TData extends Record<string, unknown>, TValue = unk
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
-  // Persist column visibility with debounce
+  // Persist column visibility con debounce; se omite el primer run (montaje) para no
+  // disparar un server-action POST de escritura innecesario en cada carga de tabla.
+  const skipFirstVisibilitySave = React.useRef(true);
   React.useEffect(() => {
     if (!tableId) return;
+    if (skipFirstVisibilitySave.current) {
+      skipFirstVisibilitySave.current = false;
+      return;
+    }
 
     const timer = setTimeout(() => {
       saveTableColumnVisibility(tableId, columnVisibility);

--- a/src/shared/components/layout/NotificationBell.tsx
+++ b/src/shared/components/layout/NotificationBell.tsx
@@ -18,8 +18,7 @@ import { Button } from '@/shared/components/ui/button';
 import { ScrollArea } from '@/shared/components/ui/scroll-area';
 import {
   dismiss,
-  getMyNotifications,
-  getMyUnreadCount,
+  getMyNotificationsWithCount,
   markAllAsRead,
   markAsRead,
 } from '@/shared/actions/notifications';
@@ -55,10 +54,9 @@ export function NotificationBell() {
 
   const refresh = useCallback(async () => {
     if (!companyId) return;
-    const [list, count] = await Promise.all([
-      getMyNotifications(companyId, false),
-      getMyUnreadCount(companyId),
-    ]);
+    // Un solo server action (lista + contador) en vez de dos: Next serializa los
+    // server actions, así que 2 llamadas = 2 POST secuenciales en el waterfall de carga.
+    const { list, count } = await getMyNotificationsWithCount(companyId, false);
     setItems(list as NotificationItem[]);
     setUnread(count);
   }, [companyId]);


### PR DESCRIPTION
…, save-visibility, notif)

Tras eliminar el prefetch storm quedó al descubierto el cuello real: un waterfall de ~5 POST server-actions SECUENCIALES en la carga de document (~5.2s). Next serializa los server actions, así que cada fetch on-mount se encola. Se atacan 3 fuentes:

1. Facets de document → al SERVER: EmployeeDocumentList los fetchea en paralelo con la data (Promise.all RSC) y los pasa como prop; _EmployeeDocumentDataTable ya no usa el useEffect que disparaba getEmployeeDocumentFacets (el POST más grande, ~1.9s).
2. saveTableColumnVisibility (DataTable compartida): se omite el primer run (montaje). Antes escribía preferencias vía server-action en CADA carga de tabla sin cambio del usuario. Aplica a TODAS las tablas.
3. NotificationBell (NavBar, toda página): getMyNotifications + getMyUnreadCount → getMyNotificationsWithCount (Promise.all server-side) = 1 POST en vez de 2.

Verificado en local: filtro facetado "Estado" muestra opciones (server-side) y filtra (?state=pendiente → server-side); tabla y datos intactos. Build + tipos OK. Falta re-medir en prod tras push.