### PR TITLE
perf(document): revertir facets-al-servidor (bloqueaba el stream RSC …

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,12 +1,9 @@
-import { getMyTicketsWithUnread } from '@/modules/ayuda/actions/support-tickets';
-import { MY_TICKETS_WITH_UNREAD_QUERY_KEY } from '@/modules/ayuda/hooks/queryKeys';
 import NavBar from '@/shared/components/layout/NavBar';
 import NotificationsAlert from '@/shared/components/layout/NotificationsAlert';
 import SideBarContainer from '@/shared/components/layout/SideBarContainer';
 import TanstackQueryProvider from '@/shared/providers/TanstackQueryProvider';
 import { getRouteRule } from '@/shared/lib/route-permissions';
 import { getSession } from '@/shared/lib/session';
-import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
@@ -30,39 +27,31 @@ export default async function DashboardLayout({ children }: { children: React.Re
     }
   }
 
-  // Prefetch server-side de los tickets sin leer para que el badge del sidebar
-  // aparezca sin un fetch extra en cliente (se rehidrata vía HydrationBoundary).
-  const queryClient = new QueryClient();
-  try {
-    await queryClient.prefetchQuery({
-      queryKey: MY_TICKETS_WITH_UNREAD_QUERY_KEY,
-      queryFn: () => getMyTicketsWithUnread(),
-    });
-  } catch {
-    // Si el prefetch falla, el cliente reintenta vía useQuery
-  }
-  const dehydratedState = dehydrate(queryClient);
+  // NOTA: antes acá se hacía `await queryClient.prefetchQuery(getMyTicketsWithUnread)`
+  // para el badge del sidebar. Eso llamaba a la API EXTERNA de TaskApp (fetch) y
+  // BLOQUEABA el render del layout — y por ende de TODA página del dashboard — hasta
+  // que esa API respondiera (en local no se notaba porque TASKAPP_BASE_URL no está
+  // seteado y devolvía []). El badge no es crítico: el hook `useMyTicketsWithUnread`
+  // lo carga en cliente sin bloquear el render inicial.
 
   return (
     <TanstackQueryProvider>
-      <HydrationBoundary state={dehydratedState}>
-        <div className={`grid grid-rows-[auto,1fr] grid-cols-[auto,1fr] h-screen `}>
-          <div className="row-span-2 ">
-            <SideBarContainer />
-          </div>
-          <div className="border-r border-b border-muted/50">
-            <NavBar />
-          </div>
-          <div className="overflow-y-auto">
-            <div className="animate-fade-in px-6 pb-6 space-y-4">
-              <Suspense fallback={null}>
-                <NotificationsAlert />
-              </Suspense>
-              {children}
-            </div>
+      <div className={`grid grid-rows-[auto,1fr] grid-cols-[auto,1fr] h-screen `}>
+        <div className="row-span-2 ">
+          <SideBarContainer />
+        </div>
+        <div className="border-r border-b border-muted/50">
+          <NavBar />
+        </div>
+        <div className="overflow-y-auto">
+          <div className="animate-fade-in px-6 pb-6 space-y-4">
+            <Suspense fallback={null}>
+              <NotificationsAlert />
+            </Suspense>
+            {children}
           </div>
         </div>
-      </HydrationBoundary>
+      </div>
     </TanstackQueryProvider>
   );
 }

--- a/src/modules/documents/features/list/components/EmployeeDocumentList.tsx
+++ b/src/modules/documents/features/list/components/EmployeeDocumentList.tsx
@@ -1,7 +1,4 @@
-import {
-  getEmployeeDocumentsPaginated,
-  getEmployeeDocumentFacets,
-} from '@/modules/documents/features/list/actions.server';
+import { getEmployeeDocumentsPaginated } from '@/modules/documents/features/list/actions.server';
 import { _EmployeeDocumentDataTable } from './_EmployeeDocumentDataTable';
 import type { DataTableSearchParams } from '@/shared/components/data-table';
 
@@ -12,19 +9,15 @@ interface Props {
 }
 
 export async function EmployeeDocumentList({ searchParams, monthly, downDocument }: Props) {
-  // Facets se fetchean en el servidor (en paralelo con los datos) y se pasan como prop:
-  // antes se cargaban con un useEffect cliente, generando un server-action POST secuencial
-  // por tabla (Next serializa los server actions → waterfall). Ahora es 1 render RSC.
-  const [{ data, total }, facets] = await Promise.all([
-    getEmployeeDocumentsPaginated(searchParams, { monthly, downDocument }),
-    getEmployeeDocumentFacets({ monthly, downDocument }),
-  ]);
+  // Solo la data paginada bloquea el render de la tabla. Los facets (opciones de filtro)
+  // se cargan en el cliente sin bloquear (ver _EmployeeDocumentDataTable): moverlos al
+  // servidor metía su query lenta en el path del stream RSC y retrasaba el LCP de la tabla.
+  const { data, total } = await getEmployeeDocumentsPaginated(searchParams, { monthly, downDocument });
 
   return (
     <_EmployeeDocumentDataTable
       data={data}
       totalRows={total}
-      facets={facets}
       searchParams={searchParams}
       monthly={monthly}
       downDocument={downDocument}

--- a/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
+++ b/src/modules/documents/features/list/components/_EmployeeDocumentDataTable.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   DataTable,
   type DataTableFacetedFilterConfig,
   type DataTableSearchParams,
 } from '@/shared/components/data-table';
 import { permanentDocumentColumns, monthlyDocumentColumns } from './document-columns';
-import { getAllEmployeeDocumentsForExport } from '../actions.server';
+import { getEmployeeDocumentFacets, getAllEmployeeDocumentsForExport } from '../actions.server';
 
 interface FacetEntry {
   value: string;
@@ -17,8 +17,6 @@ interface FacetEntry {
 interface Props {
   data: any[];
   totalRows: number;
-  /** Facets pre-calculados en el servidor (evita el server-action POST en cliente). */
-  facets: Record<string, FacetEntry[]>;
   searchParams: DataTableSearchParams;
   monthly?: boolean;
   downDocument?: boolean;
@@ -35,13 +33,20 @@ const FILTER_DEFINITIONS: { columnId: string; title: string; type: 'faceted' | '
 
 const DEFAULT_VISIBLE_FILTERS = new Set(['state', 'resource', 'documentName']);
 
-export function _EmployeeDocumentDataTable({ data, totalRows, facets, searchParams, monthly, downDocument }: Props) {
+export function _EmployeeDocumentDataTable({ data, totalRows, searchParams, monthly, downDocument }: Props) {
+  const [facets, setFacets] = useState<Record<string, FacetEntry[]> | null>(null);
   const columns = monthly ? monthlyDocumentColumns : permanentDocumentColumns;
   const tableId = downDocument
     ? 'employee-docs-baja'
     : monthly
       ? 'employee-docs-monthly'
       : 'employee-docs-permanent';
+
+  // Facets en cliente (no bloquean el render de la tabla). Se usa startTransition-like:
+  // la tabla ya se ve con la data SSR; las opciones de filtro se completan al llegar.
+  useEffect(() => {
+    getEmployeeDocumentFacets({ monthly, downDocument }).then(setFacets).catch(console.error);
+  }, [monthly, downDocument]);
 
   const buildFacetConfig = (entries: FacetEntry[] | undefined) => {
     if (!entries || entries.length === 0) return { options: [], externalCounts: new Map<string, number>() };


### PR DESCRIPTION
…de la tabla)

Medido en prod: mover getEmployeeDocumentFacets al server (await en el RSC) metió su query en el path crítico del stream, retrasando el LCP de la tabla (GET document RSC ~7.5s). Los facets son opciones de filtro, no bloquean la vista inicial → vuelven a cargarse en cliente (no bloqueante). Se conservan los otros dos fixes del waterfall (saveTableColumnVisibility no-en-montaje, NotificationBell 2→1), que son wins puros.