### PR TITLE
fix(documents): tsk-539 el diálogo de subir documento rompe al abrirse

### DIFF
--- a/src/modules/documents/shared/columns/ColumnsMonthly.tsx
+++ b/src/modules/documents/shared/columns/ColumnsMonthly.tsx
@@ -623,27 +623,36 @@ export const ColumnsMonthly: ColumnDef<Colum>[] = [
       const handleOpen = () => setOpen(!open);
 
       if (isNoPresented) {
+        // El trigger usa asChild: si no hay botón que renderizar (Invitado), Radix
+        // recibiría `false` y rompería con React.Children.only.
+        if (role === 'Invitado') return null;
+
         return (
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              {role !== 'Invitado' && <Button variant="outline">Subir documento</Button>}
+              {/* type="button": esta tabla vive dentro del <form> de la ficha del
+                  empleado y sin esto el click dispara su submit. */}
+              <Button variant="outline" type="button">
+                Subir documento
+              </Button>
             </AlertDialogTrigger>
-            <AlertDialogContent asChild>
+            {/* Sin asChild: AlertDialogContent de Radix pasa dos hijos internos
+                (Slottable + DescriptionWarning) y el Slot rompe con Children.only. */}
+            <AlertDialogContent>
               <AlertDialogHeader>
-                <div className="max-h-[90vh] overflow-y-auto">
-                  <div className="space-y-3">
-                    <div>
-                      <SimpleDocument
-                        resource={'empleado'}
-                        handleOpen={() => handleOpen()}
-                        defaultDocumentId={row.original.id_document_types}
-                        // document={document}
-                        numberDocument={row.original.document_number}
-                      />
-                    </div>
-                  </div>
-                </div>
+                <AlertDialogTitle>Subir documento</AlertDialogTitle>
+                <AlertDialogDescription className="sr-only">
+                  Formulario para cargar el documento pendiente
+                </AlertDialogDescription>
               </AlertDialogHeader>
+              <div className="max-h-[70vh] space-y-3 overflow-y-auto">
+                <SimpleDocument
+                  resource={'empleado'}
+                  handleOpen={() => handleOpen()}
+                  defaultDocumentId={row.original.id_document_types}
+                  numberDocument={row.original.document_number}
+                />
+              </div>
             </AlertDialogContent>
           </AlertDialog>
         );

--- a/src/modules/documents/shared/columns/ColumnsMonthlyEquipment.tsx
+++ b/src/modules/documents/shared/columns/ColumnsMonthlyEquipment.tsx
@@ -623,28 +623,36 @@ export const ColumnsMonthlyEquipment: ColumnDef<Colum>[] = [
       const handleOpen = () => setOpen(!open);
 
       if (isNoPresented) {
+        // El trigger usa asChild: si no hay botón que renderizar (Invitado), Radix
+        // recibiría `false` y rompería con React.Children.only.
+        if (role === 'Invitado') return null;
+
         return (
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              {role !== 'Invitado' && <Button variant="outline">Subir documento</Button>}
+              {/* type="button": esta tabla vive dentro del <form> de la ficha del
+                  equipo y sin esto el click dispara su submit. */}
+              <Button variant="outline" type="button">
+                Subir documento
+              </Button>
             </AlertDialogTrigger>
-            <AlertDialogContent asChild>
+            {/* Sin asChild: AlertDialogContent de Radix pasa dos hijos internos
+                (Slottable + DescriptionWarning) y el Slot rompe con Children.only. */}
+            <AlertDialogContent>
               <AlertDialogHeader>
-                <div className="max-h-[90vh] overflow-y-auto">
-                  <div className="space-y-3">
-                    <div>
-                      <SimpleDocument
-                        resource={'equipo'}
-                        //change
-                        handleOpen={() => handleOpen()}
-                        defaultDocumentId={row.original.id_document_types}
-                        // document={document}
-                        numberDocument={row.original.document_number || (row.original as any).vehicle_id}
-                      />
-                    </div>
-                  </div>
-                </div>
+                <AlertDialogTitle>Subir documento</AlertDialogTitle>
+                <AlertDialogDescription className="sr-only">
+                  Formulario para cargar el documento pendiente
+                </AlertDialogDescription>
               </AlertDialogHeader>
+              <div className="max-h-[70vh] space-y-3 overflow-y-auto">
+                <SimpleDocument
+                  resource={'equipo'}
+                  handleOpen={() => handleOpen()}
+                  defaultDocumentId={row.original.id_document_types}
+                  numberDocument={row.original.document_number || (row.original as any).vehicle_id}
+                />
+              </div>
             </AlertDialogContent>
           </AlertDialog>
         );

--- a/src/modules/documents/shared/columns/ExpiredColumns.tsx
+++ b/src/modules/documents/shared/columns/ExpiredColumns.tsx
@@ -735,27 +735,36 @@ export const ExpiredColums: ColumnDef<any>[] = [
       const applies = row.original.applies === 'Persona' ? 'empleado' : 'equipo';
 
       if (isNoPresented) {
+        // El trigger usa asChild: si no hay botón que renderizar (Invitado), Radix
+        // recibiría `false` y rompería con React.Children.only.
+        if (role === 'Invitado') return null;
+
         return (
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              {role !== 'Invitado' && <Button variant="outline">Subir documento</Button>}
+              {/* type="button": esta tabla vive dentro del <form> de la ficha del
+                  empleado/equipo y sin esto el click dispara su submit. */}
+              <Button variant="outline" type="button">
+                Subir documento
+              </Button>
             </AlertDialogTrigger>
-            <AlertDialogContent asChild>
+            {/* Sin asChild: AlertDialogContent de Radix pasa dos hijos internos
+                (Slottable + DescriptionWarning) y el Slot rompe con Children.only. */}
+            <AlertDialogContent>
               <AlertDialogHeader>
-                <div className="max-h-[90vh] overflow-y-auto">
-                  <div className="space-y-3">
-                    <div>
-                      <SimpleDocument
-                        resource={applies}
-                        handleOpen={() => handleOpen()}
-                        defaultDocumentId={row.original.id_document_types}
-                        // document={document}
-                        numberDocument={row.original.document_number || row.original.vehicle_id}
-                      />
-                    </div>
-                  </div>
-                </div>
+                <AlertDialogTitle>Subir documento</AlertDialogTitle>
+                <AlertDialogDescription className="sr-only">
+                  Formulario para cargar el documento pendiente
+                </AlertDialogDescription>
               </AlertDialogHeader>
+              <div className="max-h-[70vh] space-y-3 overflow-y-auto">
+                <SimpleDocument
+                  resource={applies}
+                  handleOpen={() => handleOpen()}
+                  defaultDocumentId={row.original.id_document_types}
+                  numberDocument={row.original.document_number || row.original.vehicle_id}
+                />
+              </div>
             </AlertDialogContent>
           </AlertDialog>
         );

--- a/src/shared/components/common/DocumentationDrawer.tsx
+++ b/src/shared/components/common/DocumentationDrawer.tsx
@@ -18,7 +18,14 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { storage } from '@/shared/lib/storage';
 import SimpleDocument from '@/modules/documents/features/upload/components/SimpleDocument';
-import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTrigger } from '@/shared/components/ui/alert-dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/shared/components/ui/alert-dialog';
 import { Button, buttonVariants } from '@/shared/components/ui/button';
 import { CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
 import { Skeleton } from '@/shared/components/ui/skeleton';
@@ -194,34 +201,35 @@ export const DocumentationDrawer = ({ resource, document, id }: Props) => {
                     {doc?.id_document_types?.name}
                   </p>
                 </div>
-                {doc.state === 'pendiente' && (
+                {doc.state === 'pendiente' && role !== 'Invitado' && (
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
-                      {role !== 'Invitado' && (
-                        <Button
-                          onClick={() => {
-                            setDefaultDocumentId(doc?.id_document_types?.id);
-                          }}
-                        >
-                          Subir
-                        </Button>
-                      )}
+                      <Button
+                        type="button"
+                        onClick={() => {
+                          setDefaultDocumentId(doc?.id_document_types?.id);
+                        }}
+                      >
+                        Subir
+                      </Button>
                     </AlertDialogTrigger>
-                    <AlertDialogContent asChild>
+                    {/* Sin asChild: AlertDialogContent de Radix pasa dos hijos internos
+                        (Slottable + DescriptionWarning) y el Slot rompe con Children.only. */}
+                    <AlertDialogContent>
                       <AlertDialogHeader>
-                        <div className="max-h-[90vh] overflow-y-auto">
-                          <div className="space-y-3">
-                            <div>
-                              <SimpleDocument
-                                resource={resource}
-                                handleOpen={() => handleOpen()}
-                                defaultDocumentId={defaultDocumentId}
-                                document={document}
-                              />
-                            </div>
-                          </div>
-                        </div>
+                        <AlertDialogTitle>Subir documento</AlertDialogTitle>
+                        <AlertDialogDescription className="sr-only">
+                          Formulario para cargar el documento pendiente
+                        </AlertDialogDescription>
                       </AlertDialogHeader>
+                      <div className="max-h-[70vh] space-y-3 overflow-y-auto">
+                        <SimpleDocument
+                          resource={resource}
+                          handleOpen={() => handleOpen()}
+                          defaultDocumentId={defaultDocumentId}
+                          document={document}
+                        />
+                      </div>
                     </AlertDialogContent>
                   </AlertDialog>
                 )}


### PR DESCRIPTION
AlertDialogContent tenía asChild. Radix (alert-dialog 1.1.15) le pasa dos hijos internos a DialogPrimitive.Content — Slottable + DescriptionWarning — y el Slot que activa asChild es de tipo DialogContent, así que no reconoce el Slottable creado con createSlottable("AlertDialogContent"): ve dos hijos y lanza React.Children.only. Como Radix monta el contenido recién al abrir el diálogo, el error saltaba justo al clickear "Subir documento" y, al ser un error de render, lo capturaba app/dashboard/error.tsx ("Error al cargar el panel").

- Quita asChild y agrega AlertDialogTitle/Description (faltaban para a11y).
- El trigger recibía `false` cuando el rol era Invitado: mismo Children.only. La condición ahora envuelve al AlertDialog completo.
- type="button" en los triggers: estas tablas viven dentro del <form> de la ficha del empleado/equipo y el click disparaba también su submit.

Afectaba documentos permanentes y mensuales, de empleados y de equipos.