### PR TITLE
fix(treasury): timeout al marcar como pagada una OP con muchas facturas

### DIFF
--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -1023,37 +1023,52 @@ export async function markPaymentOrderAsPaid(id: string): Promise<{
       // cobertura = pagos imputados + notas de crédito aplicadas.
       await recalcPurchaseInvoiceStatusMany(invoiceIds, tx);
 
-      // Actualizar status de gastos vinculados
-      for (const expenseId of expenseIds) {
-        const expense = await tx.expenses.findUnique({
-          where: { id: expenseId },
-          select: { id: true, amount: true, status: true },
-        });
-        if (!expense) continue;
-        if (expense.status === 'CANCELLED') continue;
+      // Actualizar status de gastos vinculados. En lote por el mismo motivo que
+      // las facturas: un gasto por iteración costaba findUnique + aggregate +
+      // update y hacía crecer la transacción de forma lineal.
+      if (expenseIds.length > 0) {
+        const [expenses, paidGroups] = await Promise.all([
+          tx.expenses.findMany({
+            where: { id: { in: expenseIds } },
+            select: { id: true, amount: true, status: true },
+          }),
+          tx.payment_order_items.groupBy({
+            by: ['expense_id'],
+            where: { expense_id: { in: expenseIds }, payment_order: { status: 'PAID' } },
+            _sum: { amount: true },
+          }),
+        ]);
 
-        const aggregate = await tx.payment_order_items.aggregate({
-          where: {
-            expense_id: expenseId,
-            payment_order: { status: 'PAID' },
-          },
-          _sum: { amount: true },
-        });
-        const paidSum = Number(aggregate._sum.amount ?? 0);
-        const total = Number(expense.amount);
+        const paidByExpense = new Map<string, number>();
+        for (const g of paidGroups) {
+          if (g.expense_id) paidByExpense.set(g.expense_id, Number(g._sum.amount ?? 0));
+        }
 
-        let nextStatus: 'PAID' | 'PARTIAL_PAID' | null = null;
-        if (paidSum >= total - 0.005) nextStatus = 'PAID';
-        else if (paidSum > 0) nextStatus = 'PARTIAL_PAID';
+        const idsByNextStatus = new Map<'PAID' | 'PARTIAL_PAID', string[]>();
+        for (const expense of expenses) {
+          if (expense.status === 'CANCELLED') continue;
 
-        if (nextStatus && expense.status !== nextStatus) {
-          await tx.expenses.update({
-            where: { id: expenseId },
-            data: { status: nextStatus },
-          });
+          const paidSum = paidByExpense.get(expense.id) ?? 0;
+          const total = Number(expense.amount);
+
+          let nextStatus: 'PAID' | 'PARTIAL_PAID' | null = null;
+          if (paidSum >= total - 0.005) nextStatus = 'PAID';
+          else if (paidSum > 0) nextStatus = 'PARTIAL_PAID';
+
+          if (!nextStatus || expense.status === nextStatus) continue;
+          const pending = idsByNextStatus.get(nextStatus);
+          if (pending) pending.push(expense.id);
+          else idsByNextStatus.set(nextStatus, [expense.id]);
+        }
+
+        for (const [status, ids] of idsByNextStatus) {
+          await tx.expenses.updateMany({ where: { id: { in: ids } }, data: { status } });
         }
       }
-    });
+    },
+    // El cuerpo ya no crece con la cantidad de ítems, pero el default de Prisma
+    // (5 s) deja poco margen ante una OP muy grande o una base con latencia alta.
+    { timeout: 30_000, maxWait: 10_000 });
 
     // Mail al proveedor (fuera de la transacción)
     let emailStatus: 'SENT' | 'NO_EMAIL' | 'FAILED' = 'FAILED';

--- a/src/shared/lib/purchase-invoice-status.ts
+++ b/src/shared/lib/purchase-invoice-status.ts
@@ -21,6 +21,9 @@ import {
 /** Cliente Prisma o el `tx` de una transacción. */
 type PrismaClientLike = typeof prisma | any;
 
+/** Estados en los que una factura todavía admite recálculo de pago. */
+const RECALCULABLE_STATUSES = ['CONFIRMED', 'PARTIAL_PAID', 'PAID'];
+
 /** Crédito de NC activas aplicable a cada factura original. */
 export async function getCreditNoteAmountsByInvoice(
   invoiceIds: string[],
@@ -81,7 +84,7 @@ export async function recalcPurchaseInvoiceStatus(
     select: { id: true, total: true, status: true, voucher_type: true },
   });
   if (!invoice) return null;
-  if (!['CONFIRMED', 'PARTIAL_PAID', 'PAID'].includes(invoice.status)) return invoice.status;
+  if (!RECALCULABLE_STATUSES.includes(invoice.status)) return invoice.status;
   if (isCreditNoteVoucherType(invoice.voucher_type)) return invoice.status;
 
   const [paidAgg, creditByInvoice, appliedCreditByInvoice] = await Promise.all([
@@ -106,12 +109,73 @@ export async function recalcPurchaseInvoiceStatus(
   return newStatus;
 }
 
+/**
+ * Versión en lote: resuelve N facturas con un número fijo de consultas en vez de
+ * repetir `recalcPurchaseInvoiceStatus` una vez por factura.
+ *
+ * El bucle anterior costaba ~4 consultas por factura (findUnique + aggregate +
+ * 2 groupBy) y las encadenaba de forma secuencial. Dentro de la transacción de
+ * `markPaymentOrderAsPaid` eso agotaba el timeout de 5 s de Prisma: una OP con
+ * 13 facturas superaba los 5300 ms y abortaba en el `groupBy` de
+ * `supplier_credit_applications`. Ahora son 4 consultas en total —
+ * `getCreditNoteAmountsByInvoice` y `getAppliedCreditByInvoice` ya recibían un
+ * array— más un `updateMany` por estado destino (a lo sumo tres).
+ */
 export async function recalcPurchaseInvoiceStatusMany(
   invoiceIds: Iterable<string>,
   client: PrismaClientLike = prisma
 ): Promise<void> {
   const unique = Array.from(new Set(invoiceIds));
-  for (const id of unique) {
-    await recalcPurchaseInvoiceStatus(id, client);
+  if (unique.length === 0) return;
+
+  const invoices = await client.purchase_invoices.findMany({
+    where: { id: { in: unique } },
+    select: { id: true, total: true, status: true, voucher_type: true },
+  });
+
+  // Mismo criterio que la versión unitaria: solo facturas en estado pagable y
+  // nunca una NC, que no se paga sino que se aplica.
+  const targets = (
+    invoices as { id: string; total: unknown; status: string; voucher_type: string }[]
+  ).filter(
+    (inv) => RECALCULABLE_STATUSES.includes(inv.status) && !isCreditNoteVoucherType(inv.voucher_type)
+  );
+  if (targets.length === 0) return;
+
+  const targetIds = targets.map((inv) => inv.id);
+
+  const [paidGroups, creditByInvoice, appliedCreditByInvoice] = await Promise.all([
+    client.payment_order_items.groupBy({
+      by: ['invoice_id'],
+      where: { invoice_id: { in: targetIds }, payment_order: { status: 'PAID' } },
+      _sum: { amount: true },
+    }),
+    getCreditNoteAmountsByInvoice(targetIds, client),
+    getAppliedCreditByInvoice(targetIds, client),
+  ]);
+
+  const paidByInvoice = new Map<string, number>();
+  for (const g of paidGroups as { invoice_id: string | null; _sum: { amount: unknown } }[]) {
+    if (g.invoice_id) paidByInvoice.set(g.invoice_id, Number(g._sum.amount ?? 0));
+  }
+
+  // Agrupar por estado destino: como mucho un updateMany por estado, en lugar
+  // de un update por factura.
+  const idsByNewStatus = new Map<string, string[]>();
+  for (const inv of targets) {
+    const newStatus = derivePurchaseInvoiceStatus({
+      total: Number(inv.total),
+      paid: paidByInvoice.get(inv.id) ?? 0,
+      creditNotes: creditByInvoice.get(inv.id) ?? 0,
+      creditApplied: appliedCreditByInvoice.get(inv.id) ?? 0,
+    });
+    if (newStatus === inv.status) continue;
+    const pending = idsByNewStatus.get(newStatus);
+    if (pending) pending.push(inv.id);
+    else idsByNewStatus.set(newStatus, [inv.id]);
+  }
+
+  for (const [status, ids] of idsByNewStatus) {
+    await client.purchase_invoices.updateMany({ where: { id: { in: ids } }, data: { status } });
   }
 }


### PR DESCRIPTION
## Problema

Marcar como pagada la OP-00471, que agrupa 13 facturas por $1.548.583,50, falla con:

```
PrismaClientKnownRequestError: Invalid `prisma.supplier_credit_applications.groupBy()` invocation:
Transaction API error: A batch query cannot be executed on an expired transaction.
The timeout for this transaction was 5000 ms, however 5375 ms passed since the start of the transaction.
```

Con órdenes de una o dos facturas no se manifestaba, que es el 97% de los casos.

## Causa

`markPaymentOrderAsPaid` abre una transacción y adentro llama a `recalcPurchaseInvoiceStatusMany`, que recorría las facturas de a una:

```ts
for (const id of unique) {
  await recalcPurchaseInvoiceStatus(id, client);
}
```

Cada iteración cuesta cuatro consultas (`findUnique` + `aggregate` + dos `groupBy`) más el `update`, todas encadenadas. El costo crece de forma lineal con la cantidad de facturas y a partir de unas diez supera el timeout de 5 s de Prisma. El bucle de gastos vinculados tenía el mismo patrón.

Distribución que explica por qué aparece recién ahora:

| Facturas por OP | Órdenes | Resultado |
|---|---|---|
| 1 | 373 | OK |
| 2 | 56 | OK |
| 3 a 6 | 34 | OK |
| 8 | 1 | OK |
| **13** | 1 | **timeout** |

## Solución

`recalcPurchaseInvoiceStatusMany` resuelve el lote completo con un `findMany`, tres agregados en paralelo y un `updateMany` por estado destino. `getCreditNoteAmountsByInvoice` y `getAppliedCreditByInvoice` ya recibían un array de ids: se las estaba llamando con un único elemento.

| | Antes | Ahora |
|---|---|---|
| Consultas, OP de 13 facturas | ~60 | 6 |
| Consultas, OP de 55 facturas | ~250 | 6 |
| Depende de la cantidad de ítems | Sí | No |

Se agrega además un `timeout` explícito de 30 s en la transacción, como margen ante latencia alta. Es red de seguridad, no el arreglo: el cuerpo ya no crece con la cantidad de ítems.

Los otros dos llamadores de `recalcPurchaseInvoiceStatusMany`, alta de pagos en compras e imputación de crédito a proveedores, se benefician sin cambios.

## Verificación

- `npm run check-types`: sin errores en los archivos tocados. Los `TS2307` de imports `.png` que aparecen son preexistentes, por falta de `next-env.d.ts`.
- `eslint` sobre ambos archivos: limpio.
- Simulación en SQL sobre los datos de producción: las 13 facturas de la OP-00471 derivan a `PAID` por $1.548.583,50, que coincide con el total de la orden. Todas al mismo estado destino, o sea un solo `updateMany`.

Sin cambios de esquema ni migraciones. La OP-00471 quedó en `CONFIRMED` con rollback limpio, así que es reintentable una vez desplegado.

## Para probar

1. Abrir la OP-00471 y marcarla como pagada.
2. Verificar que las 13 facturas quedan en Pagada.
3. Como control de no regresión, repetir con una orden de una sola factura y con una que tenga gastos vinculados.
