### PR TITLE
fix(checklist): tsk-556 el checklist no guardaba y no avisaba nada

### DIFF
--- a/src/modules/equipment/features/create/actions.server.ts
+++ b/src/modules/equipment/features/create/actions.server.ts
@@ -2,6 +2,8 @@
 import { prisma } from '@/shared/lib/prisma';
 import { getActionContext } from '@/shared/lib/server-action-context';
 import { ensurePendingDocumentsForEquipment } from '@/shared/lib/documentAlerts';
+import { supabaseServer } from '@/shared/lib/supabase/server';
+import { cookies } from 'next/headers';
 import { revalidatePath } from 'next/cache';
 
 export const UpdateVehicle = async (vehicleId: string, vehicleData: any) => {
@@ -15,6 +17,80 @@ export const UpdateVehicle = async (vehicleId: string, vehicleData: any) => {
     await ensurePendingDocumentsForEquipment(vehicleId);
   } catch (error) {
     console.error(error);
+  }
+};
+
+/**
+ * Actualiza el kilometraje desde un checklist.
+ *
+ * No pasa por `UpdateVehicle` a propósito: esa acción aborta cuando no hay
+ * cookie `actualComp`, que es siempre el caso en el flujo público de QR
+ * (/maintenance/[id]), donde el chofer nunca tuvo una empresa seleccionada. El
+ * resultado era que el kilometraje del equipo nunca se actualizaba con lo que
+ * cargaban los choferes.
+ *
+ * Como una server action es un endpoint público, acá se valida a mano lo que
+ * `actualComp` no validaba: que quien la llama esté identificado (empleado por
+ * CUIL o usuario con sesión) y que pertenezca a la empresa dueña del equipo.
+ */
+export const updateVehicleKilometerFromChecklist = async (vehicleId: string, kilometer: string) => {
+  if (!/^\d+$/.test(kilometer)) {
+    return { error: 'El kilometraje debe ser un número entero' };
+  }
+
+  try {
+    const cookiesStore = await cookies();
+    const empleadoId = cookiesStore.get('empleado_id')?.value;
+
+    const supabase = await supabaseServer();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!empleadoId && !user?.id) {
+      return { error: 'No autorizado' };
+    }
+
+    const vehicle = await prisma.vehicles.findUnique({
+      where: { id: vehicleId },
+      select: { company_id: true },
+    });
+
+    if (!vehicle?.company_id) {
+      return { error: 'Equipo inexistente' };
+    }
+
+    const perteneceALaEmpresa = empleadoId
+      ? Boolean(
+          await prisma.employees.findFirst({
+            where: { id: empleadoId, company_id: vehicle.company_id },
+            select: { id: true },
+          })
+        )
+      : Boolean(
+          (await prisma.company.findFirst({
+            where: { id: vehicle.company_id, owner_id: user!.id },
+            select: { id: true },
+          })) ??
+            (await prisma.share_company_users.findFirst({
+              where: { company_id: vehicle.company_id, profile_id: user!.id },
+              select: { id: true },
+            }))
+        );
+
+    if (!perteneceALaEmpresa) {
+      return { error: 'No autorizado' };
+    }
+
+    await prisma.vehicles.update({
+      where: { id: vehicleId },
+      data: { kilometer },
+    });
+
+    return { error: null };
+  } catch (error) {
+    console.error('Error updating vehicle kilometer from checklist:', error);
+    return { error: String(error) };
   }
 };
 

--- a/src/modules/equipment/index.ts
+++ b/src/modules/equipment/index.ts
@@ -11,6 +11,7 @@ export {
 // Create / mutate actions
 export {
   UpdateVehicle,
+  updateVehicleKilometerFromChecklist,
   insertVehicle,
   updateVehicleById,
   updateVehicleByIdAndCompany,

--- a/src/modules/hse/features/checklist/components/ChecklistSergio.tsx
+++ b/src/modules/hse/features/checklist/components/ChecklistSergio.tsx
@@ -5,8 +5,10 @@ import { Input } from '@/shared/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
 
-import { UpdateVehicle } from '@/modules/equipment/features/create/actions.server';
+import { updateVehicleKilometerFromChecklist } from '@/modules/equipment/features/create/actions.server';
 import { CreateNewFormAnswer } from '@/modules/forms/features/answers/actions.server';
+import { missingFieldsMessage, parseKilometraje, scrollToFirstInvalidField } from '@/shared/lib/form-errors';
+import { FormErrorSummary } from './FormErrorSummary';
 import { cn } from '@/shared/lib/utils';
 import { useLoggedUserStore } from '@/shared/store/loggedUser';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -14,7 +16,7 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { format } from 'date-fns';
 import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -154,6 +156,7 @@ export default function VehicleInspectionChecklist({
   const [activeTab, setActiveTab] = useState('luces');
   const params = useParams();
   const router = useRouter();
+  const formRef = useRef<HTMLFormElement>(null);
   // const params = new URLSearchParams(searchParams as any);
 
   //   'equipments?.find((equipment) => equipment.value === default_equipment_id)',
@@ -179,25 +182,60 @@ export default function VehicleInspectionChecklist({
             chofer: currentUser?.[0].fullname?.toLocaleUpperCase(),
           },
   });
+  // Los ítems viven repartidos en pestañas, así que además de avisar hay que
+  // abrir la pestaña donde está el error: si no, el usuario ve el toast pero no
+  // encuentra qué le falta.
+  const irAlPrimerError = (errors: typeof form.formState.errors = form.formState.errors) => {
+    const erroresPorSeccion = errors as Record<string, unknown>;
+    const seccionConError = Object.keys(checklistItems).find((section) => erroresPorSeccion[section]);
+
+    if (seccionConError) {
+      setActiveTab(seccionConError);
+    }
+
+    // Radix desmonta el contenido de las pestañas ocultas, así que el campo no
+    // existe en el DOM hasta que la pestaña nueva se pinta. Dos frames esperan
+    // ese pintado de forma determinista.
+    requestAnimationFrame(() => requestAnimationFrame(() => scrollToFirstInvalidField(formRef.current)));
+  };
+
+  const onInvalid = (errors: typeof form.formState.errors) => {
+    toast.error(missingFieldsMessage(errors));
+    irAlPrimerError(errors);
+  };
+
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     const equipment = equipments?.find((equipment) => equipment.value === data.movil);
-    //Si el kilometraje es menor al actual, marcar un error y no permitir guardar
-    if (equipment?.intern_number && Number(data.kilometraje) < Number(equipment.kilometer)) {
-      form.setError('kilometraje', {
-        type: 'manual',
-        message: `El kilometraje no puede ser menor al actual ${equipment.kilometer}`,
-      });
+
+    const kilometraje = parseKilometraje(String(data.kilometraje ?? ''));
+
+    if ('error' in kilometraje) {
+      form.setError('kilometraje', { type: 'manual', message: kilometraje.error }, { shouldFocus: true });
+      toast.error(kilometraje.error);
+      scrollToFirstInvalidField(formRef.current);
       return;
     }
-    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), data), {
+
+    //Si el kilometraje es menor al actual, marcar un error y no permitir guardar
+    if (equipment?.intern_number && kilometraje.value < Number(equipment.kilometer)) {
+      const message = `El kilometraje no puede ser menor al actual ${equipment.kilometer}`;
+      form.setError('kilometraje', { type: 'manual', message }, { shouldFocus: true });
+      toast.error(message);
+      scrollToFirstInvalidField(formRef.current);
+      return;
+    }
+
+    const answer = { ...data, kilometraje: kilometraje.normalized };
+
+    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), answer), {
       loading: 'Guardando...',
       success: 'Checklist guardado correctamente',
       error: 'Ocurrió un error al guardar el checklist',
     });
 
     //Comparar el kilometraje con el del equipo y si es mayor actualizarlo
-    if (equipment && Number(data.kilometraje) > Number(equipment.kilometer)) {
-      await UpdateVehicle(equipment.value, { kilometer: data.kilometraje });
+    if (equipment && kilometraje.value > Number(equipment.kilometer)) {
+      await updateVehicleKilometerFromChecklist(equipment.value, kilometraje.normalized);
     }
 
     router.refresh();
@@ -335,7 +373,7 @@ export default function VehicleInspectionChecklist({
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <form ref={formRef} onSubmit={form.handleSubmit(onSubmit, onInvalid)} className="space-y-6">
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               <FormField
                 control={form.control}
@@ -423,7 +461,7 @@ export default function VehicleInspectionChecklist({
                   <FormItem>
                     <FormLabel>KILOMETRAJE</FormLabel>
                     <FormControl>
-                      <Input disabled={defaultAnswer?.length ? true : false} {...field} />
+                      <Input disabled={defaultAnswer?.length ? true : false} inputMode="numeric" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -538,15 +576,16 @@ export default function VehicleInspectionChecklist({
               )}
             />
 
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-4 sm:space-y-0">
-              {defaultAnswer?.length ? (
-                false
-              ) : (
-                <Button type="submit" className="w-full sm:w-auto">
-                  Guardar Checklist
-                </Button>
-              )}
-            </div>
+            {defaultAnswer?.length ? null : (
+              <div className="flex flex-col gap-3">
+                <FormErrorSummary control={form.control} onGoToFirstError={irAlPrimerError} />
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-4 sm:space-y-0">
+                  <Button type="submit" className="w-full sm:w-auto">
+                    Guardar Checklist
+                  </Button>
+                </div>
+              </div>
+            )}
           </form>
         </Form>
       </CardContent>

--- a/src/modules/hse/features/checklist/components/DynamicChecklistForm.tsx
+++ b/src/modules/hse/features/checklist/components/DynamicChecklistForm.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { UpdateVehicle } from '@/modules/equipment/features/create/actions.server';
+import { updateVehicleKilometerFromChecklist } from '@/modules/equipment/features/create/actions.server';
 import { CreateNewFormAnswer } from '@/modules/forms/features/answers/actions.server';
+import { missingFieldsMessage, parseKilometraje, scrollToFirstInvalidField } from '@/shared/lib/form-errors';
+import { FormErrorSummary } from './FormErrorSummary';
 import { PDFPreviewDialog } from '@/shared/components/pdf/PDFPreviewDialog';
 import dynamic from 'next/dynamic';
 // Carga diferida: react-pdf (~478KB) solo se descarga al previsualizar/generar el PDF.
@@ -26,7 +28,7 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { format } from 'date-fns';
 import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
@@ -267,6 +269,7 @@ export default function DynamicChecklistForm({
   const [formSchema] = useState(() => generateSchema(config));
   const params = useParams();
   const router = useRouter();
+  const formRef = useRef<HTMLFormElement>(null);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: defaultAnswer?.length
@@ -295,27 +298,46 @@ export default function DynamicChecklistForm({
   const actualCompany = useLoggedUserStore((state) => state.actualCompany);
 
 
+  // Sin esto, un checklist incompleto no da ninguna señal: el submit se corta en
+  // la validación y los radios de Radix no reciben foco, así que la pantalla ni
+  // se mueve.
+  const onInvalid = (errors: typeof form.formState.errors) => {
+    toast.error(missingFieldsMessage(errors));
+    scrollToFirstInvalidField(formRef.current);
+  };
+
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     //Comparar el kilometraje con el del equipo y si es mayor actualizarlo
     const equipment = equipments?.find((equipment) => equipment.value === data.movil);
 
-    //Si el kilometraje es menor al actual, marcar un error y no permitir guardar
-    if (equipment?.intern_number && Number(data.kilometraje) < Number(equipment.kilometer)) {
-      form.setError('kilometraje', {
-        type: 'manual',
-        message: `El kilometraje no puede ser menor al actual ${equipment.kilometer}`,
-      });
+    const kilometraje = parseKilometraje(String(data.kilometraje ?? ''));
+
+    if ('error' in kilometraje) {
+      form.setError('kilometraje', { type: 'manual', message: kilometraje.error }, { shouldFocus: true });
+      toast.error(kilometraje.error);
+      scrollToFirstInvalidField(formRef.current);
       return;
     }
 
-    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), data), {
+    //Si el kilometraje es menor al actual, marcar un error y no permitir guardar
+    if (equipment?.intern_number && kilometraje.value < Number(equipment.kilometer)) {
+      const message = `El kilometraje no puede ser menor al actual ${equipment.kilometer}`;
+      form.setError('kilometraje', { type: 'manual', message }, { shouldFocus: true });
+      toast.error(message);
+      scrollToFirstInvalidField(formRef.current);
+      return;
+    }
+
+    const answer = { ...data, kilometraje: kilometraje.normalized };
+
+    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), answer), {
       loading: 'Guardando...',
       success: 'Checklist guardado correctamente',
       error: 'Ocurrió un error al guardar el checklist',
     });
 
-    if (equipment?.intern_number && Number(data.kilometraje) > Number(equipment.kilometer)) {
-      await UpdateVehicle(equipment.value, { kilometer: data.kilometraje });
+    if (equipment?.intern_number && kilometraje.value > Number(equipment.kilometer)) {
+      await updateVehicleKilometerFromChecklist(equipment.value, kilometraje.normalized);
     } //! mover a la funcion create
 
     router.refresh();
@@ -392,7 +414,7 @@ export default function DynamicChecklistForm({
       </div>
       <CardContent>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <form ref={formRef} onSubmit={form.handleSubmit(onSubmit, onInvalid)} className="space-y-6">
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               <FormField
                 control={form.control}
@@ -477,6 +499,9 @@ export default function DynamicChecklistForm({
                           <FormControl>
                             <Input
                               disabled={item.disabled ? item.disabled : defaultAnswer?.length ? true : false}
+                              // Teclado numérico en el celular: es donde aparecen los
+                              // kilometrajes tipeados con separador de miles.
+                              inputMode={item.id === 'kilometraje' ? 'numeric' : undefined}
                               {...field}
                             />
                           </FormControl>
@@ -573,8 +598,11 @@ export default function DynamicChecklistForm({
               )}
             />
             {!defaultAnswer?.length ? (
-              <div className="flex justify-end">
-                <Button type="submit">Guardar Checklist</Button>
+              <div className="flex flex-col gap-3">
+                <FormErrorSummary control={form.control} onGoToFirstError={() => scrollToFirstInvalidField(formRef.current)} />
+                <div className="flex justify-end">
+                  <Button type="submit">Guardar Checklist</Button>
+                </div>
               </div>
             ) : null}
           </form>

--- a/src/modules/hse/features/checklist/components/FormErrorSummary.tsx
+++ b/src/modules/hse/features/checklist/components/FormErrorSummary.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { AlertCircle } from 'lucide-react';
+import { Control, FieldValues, useFormState } from 'react-hook-form';
+
+import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
+import { Button } from '@/shared/components/ui/button';
+import { countFieldErrors } from '@/shared/lib/form-errors';
+
+/**
+ * Aviso persistente de campos sin completar, para poner junto al botón de guardar.
+ *
+ * El toast solo no alcanza en el celular: dura unos segundos, aparece lejos del
+ * campo y el chofer que mira tarde se queda sin saber qué pasó. Esto se queda en
+ * pantalla hasta que el checklist está completo, y el contador baja a medida que
+ * se responde.
+ *
+ * Se suscribe con `useFormState` en vez de leer `form.formState` en el
+ * componente padre: así el contador re-renderiza solo este bloque y no el
+ * formulario entero en cada tecla.
+ */
+export function FormErrorSummary<TFieldValues extends FieldValues>({
+  control,
+  onGoToFirstError,
+}: {
+  control: Control<TFieldValues>;
+  onGoToFirstError: () => void;
+}) {
+  const { errors, isSubmitted } = useFormState({ control });
+  const total = countFieldErrors(errors);
+  const visible = isSubmitted && total > 0;
+
+  // El contenedor se monta siempre, aunque esté vacío: si apareciera y
+  // desapareciera, un lector de pantalla podría no anunciar el segundo intento
+  // fallido.
+  return (
+    <div role="alert" aria-live="assertive" className="w-full">
+      {visible && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {total === 1 ? 'Falta 1 respuesta para poder guardar' : `Faltan ${total} respuestas para poder guardar`}
+          </AlertTitle>
+          <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span>Los campos incompletos están marcados en rojo.</span>
+            <Button type="button" variant="outline" size="sm" onClick={onGoToFirstError} className="w-full sm:w-auto">
+              Ir al primero
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/src/modules/hse/features/checklist/components/VehicleInspectionChecklist.tsx
+++ b/src/modules/hse/features/checklist/components/VehicleInspectionChecklist.tsx
@@ -6,7 +6,9 @@ import { Input } from '@/shared/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/components/ui/tabs';
 
-import { UpdateVehicle } from '@/modules/equipment/features/create/actions.server';
+import { updateVehicleKilometerFromChecklist } from '@/modules/equipment/features/create/actions.server';
+import { missingFieldsMessage, parseKilometraje, scrollToFirstInvalidField } from '@/shared/lib/form-errors';
+import { FormErrorSummary } from './FormErrorSummary';
 import { CreateNewFormAnswer } from '@/modules/forms/features/answers/actions.server';
 import { cn } from '@/shared/lib/utils';
 import { useLoggedUserStore } from '@/shared/store/loggedUser';
@@ -15,7 +17,7 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { format } from 'date-fns';
 import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -195,6 +197,7 @@ export default function VehicleMaintenanceChecklist({
   const [activeTab, setActiveTab] = useState('general');
   const params = useParams();
   const router = useRouter();
+  const formRef = useRef<HTMLFormElement>(null);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -218,23 +221,58 @@ export default function VehicleMaintenanceChecklist({
           },
   });
 
+  // Los ítems viven repartidos en pestañas, así que además de avisar hay que
+  // abrir la pestaña donde está el error: si no, el usuario ve el toast pero no
+  // encuentra qué le falta.
+  const irAlPrimerError = (errors: typeof form.formState.errors = form.formState.errors) => {
+    const erroresPorSeccion = errors as Record<string, unknown>;
+    const seccionConError = Object.keys(checklistItems03).find((section) => erroresPorSeccion[section]);
+
+    if (seccionConError) {
+      setActiveTab(seccionConError);
+    }
+
+    // Radix desmonta el contenido de las pestañas ocultas, así que el campo no
+    // existe en el DOM hasta que la pestaña nueva se pinta. Dos frames esperan
+    // ese pintado de forma determinista.
+    requestAnimationFrame(() => requestAnimationFrame(() => scrollToFirstInvalidField(formRef.current)));
+  };
+
+  const onInvalid = (errors: typeof form.formState.errors) => {
+    toast.error(missingFieldsMessage(errors));
+    irAlPrimerError(errors);
+  };
+
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     const equipment = equipments?.find((equipment) => equipment.value === data.movil);
-    if (equipment?.intern_number && Number(data.kilometraje) < Number(equipment.kilometer)) {
-      form.setError('kilometraje', {
-        type: 'manual',
-        message: `El kilometraje no puede ser menor al actual ${equipment.kilometer}`,
-      });
+
+    const kilometraje = parseKilometraje(String(data.kilometraje ?? ''));
+
+    if ('error' in kilometraje) {
+      form.setError('kilometraje', { type: 'manual', message: kilometraje.error }, { shouldFocus: true });
+      toast.error(kilometraje.error);
+      scrollToFirstInvalidField(formRef.current);
       return;
     }
-    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), data), {
+
+    if (equipment?.intern_number && kilometraje.value < Number(equipment.kilometer)) {
+      const message = `El kilometraje no puede ser menor al actual ${equipment.kilometer}`;
+      form.setError('kilometraje', { type: 'manual', message }, { shouldFocus: true });
+      toast.error(message);
+      scrollToFirstInvalidField(formRef.current);
+      return;
+    }
+
+    const answer = { ...data, kilometraje: kilometraje.normalized };
+
+    toast.promise(CreateNewFormAnswer(resetQrSelection ? form_Info[0].id : (params.id as string), answer), {
       loading: 'Guardando...',
       success: 'Checklist guardado correctamente',
       error: 'Ocurrió un error al guardar el checklist',
     });
     //Comparar el kilometraje con el del equipo y si es mayor actualizarlo
-    if (equipment && Number(data.kilometraje) > Number(equipment.kilometer)) {
-      await UpdateVehicle(equipment.value, { kilometer: data.kilometraje });
+    if (equipment && kilometraje.value > Number(equipment.kilometer)) {
+      await updateVehicleKilometerFromChecklist(equipment.value, kilometraje.normalized);
     }
 
     router.refresh();
@@ -297,7 +335,7 @@ export default function VehicleMaintenanceChecklist({
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <form ref={formRef} onSubmit={form.handleSubmit(onSubmit, onInvalid)} className="space-y-6">
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               <FormField
                 control={form.control}
@@ -385,7 +423,7 @@ export default function VehicleMaintenanceChecklist({
                   <FormItem>
                     <FormLabel>KILOMETRAJE</FormLabel>
                     <FormControl>
-                      <Input disabled={defaultAnswer?.length ? true : false} {...field} />
+                      <Input disabled={defaultAnswer?.length ? true : false} inputMode="numeric" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -501,15 +539,16 @@ export default function VehicleMaintenanceChecklist({
               )}
             />
 
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-4 sm:space-y-0">
-              {defaultAnswer?.length ? (
-                false
-              ) : (
-                <Button type="submit" className="w-full sm:w-auto">
-                  Guardar Checklist
-                </Button>
-              )}
-            </div>
+            {defaultAnswer?.length ? null : (
+              <div className="flex flex-col gap-3">
+                <FormErrorSummary control={form.control} onGoToFirstError={irAlPrimerError} />
+                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-4 sm:space-y-0">
+                  <Button type="submit" className="w-full sm:w-auto">
+                    Guardar Checklist
+                  </Button>
+                </div>
+              </div>
+            )}
           </form>
         </Form>
       </CardContent>

--- a/src/shared/lib/form-errors.ts
+++ b/src/shared/lib/form-errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Utilidades para que un formulario que falla la validación no quede en silencio.
+ *
+ * react-hook-form enfoca el primer campo con error, pero solo si ese campo es un
+ * input nativo. Los controles construidos sobre Radix (RadioGroup, Select) son
+ * botones/divs sin ref enfocable, así que no reciben foco y la pantalla no se
+ * mueve: el usuario toca "Guardar", no pasa nada visible y cree que la app se
+ * colgó. Estas funciones cubren ese hueco.
+ */
+
+/**
+ * Cuenta los campos con error, incluidos los agrupados por sección
+ * (ej. `errors.luces['Luces Altas']` en el checklist semanal).
+ */
+export function countFieldErrors(errors: unknown): number {
+  if (!errors || typeof errors !== 'object') return 0;
+
+  const node = errors as Record<string, unknown>;
+  // Hoja: react-hook-form deja `message`/`type` en el error de cada campo.
+  if (typeof node.message === 'string' || typeof node.type === 'string') return 1;
+
+  return Object.values(node).reduce<number>((total, value) => total + countFieldErrors(value), 0);
+}
+
+/**
+ * Lleva la vista al primer control inválido del formulario y lo enfoca.
+ *
+ * Ancla en `aria-invalid="true"` (que `FormControl` ya pone en el control) y cae
+ * al mensaje de error (`*-form-item-message`) para los controles que no lo
+ * propagan. `querySelector` con selector múltiple devuelve el primero en orden
+ * de documento, que es el que el usuario percibe como "el primero".
+ */
+export function scrollToFirstInvalidField(container?: HTMLElement | null): void {
+  if (typeof document === 'undefined') return;
+
+  const root: ParentNode = container ?? document;
+  const target = root.querySelector<HTMLElement>('[aria-invalid="true"], [id$="-form-item-message"]');
+  if (!target) return;
+
+  target.scrollIntoView({ behavior: resolveScrollBehavior(target), block: 'center' });
+
+  // `preventScroll` evita que el foco haga un salto brusco y pise el scroll suave.
+  const focusable = isFocusable(target) ? target : target.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+  focusable?.focus({ preventScroll: true });
+}
+
+/**
+ * Elige entre salto instantáneo y desplazamiento animado.
+ *
+ * `globals.css` define `html { scroll-behavior: smooth }`, así que pasar
+ * `'auto'` NO desactiva la animación: por spec, `'auto'` usa el
+ * `scroll-behavior` computado del elemento. El único valor que fuerza el salto
+ * es `'instant'`.
+ *
+ * Se salta instantáneo en dos casos: cuando el usuario pidió menos movimiento,
+ * y cuando el campo está lejos — la duración del scroll suave la fija el
+ * navegador y crece con la distancia, así que en un checklist de 18 preguntas
+ * el recorrido se siente lento y puede marear.
+ */
+function resolveScrollBehavior(target: HTMLElement): ScrollBehavior {
+  const prefiereMenosMovimiento = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  if (prefiereMenosMovimiento) return 'instant';
+
+  const distancia = Math.abs(target.getBoundingClientRect().top - window.innerHeight / 2);
+  return distancia > window.innerHeight * 2 ? 'instant' : 'smooth';
+}
+
+const FOCUSABLE_SELECTOR = 'input, select, textarea, button, [href], [tabindex]:not([tabindex="-1"])';
+
+function isFocusable(element: HTMLElement): boolean {
+  return element.matches(FOCUSABLE_SELECTOR);
+}
+
+/**
+ * Mensaje para el toast que acompaña al scroll.
+ */
+export function missingFieldsMessage(errors: unknown): string {
+  const total = countFieldErrors(errors);
+  return total === 1
+    ? 'Falta completar 1 campo obligatorio'
+    : `Faltan completar ${total} campos obligatorios`;
+}
+
+/**
+ * Normaliza el kilometraje tipeado a mano.
+ *
+ * En el celular es habitual escribirlo con separador de miles ("49.900"), y
+ * `Number('49.900')` da 49,9: el valor queda por debajo del kilometraje del
+ * equipo y el guardado se bloquea sin explicación. Acá se limpian espacios y
+ * separadores de miles, y se rechaza explícitamente lo que no sea un número.
+ */
+export function parseKilometraje(value: string): { value: number; normalized: string } | { error: string } {
+  const raw = (value ?? '').trim();
+  if (!raw) return { error: 'El kilometraje es requerido' };
+
+  // Separadores de miles: puntos o comas seguidos de exactamente 3 dígitos.
+  const withoutThousandSeparators = raw.replace(/\s/g, '').replace(/[.,](?=\d{3}\b)/g, '');
+
+  if (!/^\d+$/.test(withoutThousandSeparators)) {
+    return { error: 'Ingresá el kilometraje solo con números, sin puntos ni comas' };
+  }
+
+  return { value: Number(withoutThousandSeparators), normalized: withoutThousandSeparators };
+}


### PR DESCRIPTION
## Problema

Ticket **#556** — "El chofer del interno 104 no puede guardar los checklist diarios. Cuando le da al botón de guardar no lo guarda."

Al tocar **Guardar Checklist** con algún campo obligatorio sin completar no pasaba absolutamente nada: ni toast, ni scroll, ni mensaje a la vista. El chofer creía que la app se colgaba. Verificado contra la base: el submit ni salía del navegador, no se insertaba nada.

## Causa

`handleSubmit` se llamaba sin handler `onInvalid`, así que la validación cortaba el submit en silencio.

react-hook-form enfoca el primer campo con error, pero **solo si es un input nativo**. Los `RadioGroup` de Radix son botones sin ref enfocable: no reciben foco y la pantalla no se mueve. En el checklist diario **15 de los 18 campos obligatorios son radios**, así que el caso silencioso es el habitual, no la excepción. Con un input de texto vacío sí scrolleaba solo; con un radio, no.

Segundo camino silencioso: el kilometraje escrito con separador de miles (`49.900`) se parseaba como **49,9**, caía por debajo del kilometraje del equipo y disparaba un `setError` + `return` temprano, dejando el formulario entero en verde y mudo.

## Qué se hizo

- `onInvalid` en los tres checklists: toast con cuántos campos faltan, scroll al primer campo inválido y foco.
- Aviso persistente junto al botón de guardar (`FormErrorSummary`) con contador en vivo y botón **"Ir al primero"**. El toast se va solo a los segundos; el aviso se queda hasta completar.
- En los checklists con pestañas se abre la que contiene el error antes de scrollear, porque Radix desmonta el contenido de las ocultas.
- `parseKilometraje` limpia separadores de miles y rechaza lo que no sea numérico con un mensaje que dice cómo corregirlo, en vez de reinterpretar el valor por su cuenta y guardar un odómetro equivocado.
- El scroll usa `'instant'` cuando el usuario pidió menos movimiento o cuando el campo está a más de dos pantallas. `'auto'` no servía: `globals.css` define `scroll-behavior: smooth` en `html` y, por spec, `'auto'` toma ese valor computado.
- `inputMode="numeric"` en el campo de kilometraje.

### Bug adicional incluido

El kilometraje del equipo **nunca se actualizaba desde el flujo de QR**: `UpdateVehicle` aborta con `if (!companyId) return []`, y la cookie `actualComp` no existe nunca en `/maintenance`. Por eso los kilometrajes de la flota quedaban desfasados respecto de sus propios checklists.

Se agrega `updateVehicleKilometerFromChecklist`, que valida identidad (empleado por CUIL o sesión) y pertenencia a la empresa dueña del equipo, en lugar de confiar en una cookie falsificable.

## Cómo se verificó

Con un equipo de prueba creado y borrado en el momento (ya no queda ningún rastro):

| Escenario | Antes | Ahora |
|---|---|---|
| Falta un ítem arriba de todo | Nada, cero señal | Toast + aviso + salta solo al campo |
| Buscar el campo faltante | Revisar 18 ítems a mano | Botón "Ir al primero" |
| Kilometraje `49.900` | Silencio absoluto | Mensaje inline + toast; lo lee como 49.900 km |
| Formulario completo | Guardaba | Guarda, y el aviso desaparece solo |

Se escribió `50.200` con punto y en la base quedó `50200` normalizado, con el kilometraje del vehículo actualizado sin cookie `actualComp`.

`tsc --noEmit`: 0 errores.

## Pendiente, fuera de este PR

Los campos `interno`, `dominio`, `modelo`, `marca`, `chofer` y `fecha` son `required` **y** `disabled`. Si un equipo no tiene alguno cargado, el usuario ve "faltan campos", el scroll lo lleva a un input gris que no puede tocar y no hay salida: es el mismo bug con otro origen. Requiere decidir si salen del schema o pasan a `readOnly`.
