### PR TITLE
feat(treasury): tsk-576 órdenes de pago multimoneda

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2589,6 +2589,13 @@ model payment_orders {
   number                 Int
   full_number            String
   date                   DateTime             @db.Timestamptz
+  /// Moneda de la orden (tsk-576). Por defecto ARS, incluso si la factura del
+  /// proveedor está en dólares. total_amount, retentions_total y net_to_pay
+  /// están expresados en esta moneda.
+  currency               String               @default("ARS")
+  /// Tipo de cambio de referencia. El que se aplicó a cada comprobante está en
+  /// payment_order_items, porque cada uno puede traer el suyo.
+  exchange_rate          Decimal              @default(1) @db.Decimal(15, 4)
   total_amount           Decimal              @db.Decimal(15, 2)
   retentions_total       Decimal              @default(0) @db.Decimal(15, 2)
   net_to_pay             Decimal?             @db.Decimal(15, 2)
@@ -2717,7 +2724,17 @@ model payment_order_items {
   payment_order_id String  @db.Uuid
   invoice_id       String? @db.Uuid
   expense_id       String? @db.Uuid
+  /// Importe imputado EN LA MONEDA DEL COMPROBANTE. Es lo que hace que el saldo
+  /// de una factura en dólares cierre contra su propio total, sin depender de
+  /// ningún tipo de cambio al leer (tsk-576).
   amount           Decimal @db.Decimal(15, 2)
+  /// Moneda del comprobante imputado. Gastos y pagos a cuenta van siempre en ARS.
+  currency         String  @default("ARS")
+  /// Tipo de cambio aplicado a este ítem, tomado de la factura (snapshot).
+  exchange_rate    Decimal @default(1) @db.Decimal(15, 4)
+  /// `amount` convertido a la moneda de la OP. Es lo que suma para total_amount
+  /// y lo que cuadra contra los pagos.
+  amount_in_order_currency Decimal @db.Decimal(15, 2)
   discount_pct     Decimal @default(0) @db.Decimal(5, 2)
   /// Pago a cuenta: ítem sin comprobante que genera saldo a favor del proveedor.
   is_on_account    Boolean @default(false)

--- a/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
+++ b/src/app/dashboard/treasury/payment-orders/[id]/edit/page.tsx
@@ -21,6 +21,8 @@ export default async function EditPaymentOrderPage({
     id: order.id,
     full_number: order.full_number,
     supplier_id: order.supplier_id,
+    currency: order.currency,
+    exchange_rate: order.exchange_rate,
     date: new Date(order.date).toISOString().slice(0, 10),
     scheduled_payment_date: order.scheduled_payment_date
       ? new Date(order.scheduled_payment_date).toISOString().slice(0, 10)
@@ -31,6 +33,8 @@ export default async function EditPaymentOrderPage({
       expense_id: i.expense_id ?? null,
       invoice_label: i.invoice?.full_number ?? i.expense?.full_number ?? null,
       amount: i.amount.toFixed(2),
+      currency: i.currency,
+      exchange_rate: i.exchange_rate,
       discount_pct: i.discount_pct,
       is_on_account: i.is_on_account,
     })),

--- a/src/modules/treasury/features/payment-orders/actions.server.ts
+++ b/src/modules/treasury/features/payment-orders/actions.server.ts
@@ -26,6 +26,7 @@ import {
   recalcPurchaseInvoiceStatusMany,
 } from '@/shared/lib/purchase-invoice-status';
 import { CREDIT_NOTE_VOUCHER_TYPES } from '@/shared/lib/purchase-invoice-balance';
+import { convertAmount, effectiveRate } from '@/shared/lib/currency-conversion';
 
 const columnMap: Record<string, string> = { status: 'status' };
 const textFilterColumns = ['full_number'];
@@ -233,12 +234,16 @@ export async function getPaymentOrderById(id: string) {
   if (!order) return null;
   return {
     ...order,
+    // Decimal -> number para poder pasarlo a componentes cliente.
+    exchange_rate: Number(order.exchange_rate),
     total_amount: Number(order.total_amount),
     retentions_total: Number(order.retentions_total),
     net_to_pay: order.net_to_pay !== null ? Number(order.net_to_pay) : null,
     items: order.items.map((i) => ({
       ...i,
       amount: Number(i.amount),
+      exchange_rate: Number(i.exchange_rate),
+      amount_in_order_currency: Number(i.amount_in_order_currency),
       discount_pct: Number(i.discount_pct),
       invoice: i.invoice ? { ...i.invoice, total: Number(i.invoice.total) } : null,
       expense: i.expense ? { ...i.expense, amount: Number(i.expense.amount) } : null,
@@ -356,6 +361,11 @@ export async function getPendingPurchaseInvoices(supplierId: string) {
       subtotal: true,
       vat_amount: true,
       total: true,
+      // La OP se arma por defecto en ARS aunque la factura esté en dólares: el
+      // formulario necesita la moneda y el tipo de cambio del comprobante para
+      // convertir (tsk-576).
+      currency: true,
+      exchange_rate: true,
       // Solo cuentan las imputaciones de OPs no anuladas: al anular una OP sus
       // items se conservan (audit), pero no deben descontar del saldo pendiente.
       payment_order_items: {
@@ -389,6 +399,9 @@ export async function getPendingPurchaseInvoices(supplierId: string) {
         total,
         already_paid: Math.round(alreadyPaid * 100) / 100,
         remaining,
+        // total, already_paid y remaining están en esta moneda, no en la de la OP.
+        currency: inv.currency ?? 'ARS',
+        exchange_rate: Number(inv.exchange_rate ?? 1),
       };
     })
     .filter((inv) => inv.remaining > 0);
@@ -478,7 +491,23 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
 
   try {
     await requirePermission('tesoreria.create');
-    const totalAmount = parsed.data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
+    // El total se suma en la moneda de la orden: sumar los `amount` crudos
+    // mezclaría dólares con pesos (tsk-576).
+    const orderCurrency = parsed.data.currency ?? 'ARS';
+    const orderRef = { currency: orderCurrency, exchange_rate: parsed.data.exchange_rate ?? 1 };
+    const itemsWithConversion = parsed.data.items.map((i) => {
+      const amount = parseFloat(i.amount);
+      const itemCurrency = i.currency ?? 'ARS';
+      const rate = effectiveRate({ currency: itemCurrency, exchange_rate: i.exchange_rate ?? 1 }, orderRef);
+      return {
+        ...i,
+        amount,
+        itemCurrency,
+        rate,
+        converted: convertAmount({ amount, from: itemCurrency, to: orderCurrency, rate }),
+      };
+    });
+    const totalAmount = itemsWithConversion.reduce((acc, i) => acc + i.converted, 0);
     const retentions = (parsed.data.retentions ?? []).map((r) => ({
       tax_type_id: r.tax_type_id,
       base_amount: Math.round(Number(r.base_amount) * 100) / 100,
@@ -545,6 +574,8 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
         scheduled_payment_date: parsed.data.scheduled_payment_date
           ? new Date(parsed.data.scheduled_payment_date)
           : null,
+        currency: orderCurrency,
+        exchange_rate: parsed.data.exchange_rate ?? 1,
         total_amount: Math.round(totalAmount * 100) / 100,
         retentions_total: retentionsTotal,
         net_to_pay: netToPay,
@@ -552,11 +583,16 @@ export async function createPaymentOrder(data: PaymentOrderFormData) {
         status: 'DRAFT',
         created_by: user.id,
         items: {
-          create: parsed.data.items.map((i) => ({
+          create: itemsWithConversion.map((i) => ({
             invoice_id: i.invoice_id || null,
             expense_id: i.expense_id || null,
             is_on_account: i.is_on_account ?? false,
-            amount: parseFloat(i.amount),
+            // amount queda en la moneda del comprobante para que el saldo de la
+            // factura cierre contra su propio total.
+            amount: i.amount,
+            currency: i.itemCurrency,
+            exchange_rate: i.rate,
+            amount_in_order_currency: i.converted,
             discount_pct: Math.round((i.discount_pct ?? 0) * 100) / 100,
           })),
         },
@@ -621,7 +657,23 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
 
   try {
     await requirePermission('tesoreria.update');
-    const totalAmount = parsed.data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
+    // Igual que en createPaymentOrder: el total se suma en la moneda de la orden
+    // para no mezclar dólares con pesos (tsk-576).
+    const orderCurrency = parsed.data.currency ?? 'ARS';
+    const orderRef = { currency: orderCurrency, exchange_rate: parsed.data.exchange_rate ?? 1 };
+    const itemsWithConversion = parsed.data.items.map((i) => {
+      const amount = parseFloat(i.amount);
+      const itemCurrency = i.currency ?? 'ARS';
+      const rate = effectiveRate({ currency: itemCurrency, exchange_rate: i.exchange_rate ?? 1 }, orderRef);
+      return {
+        ...i,
+        amount,
+        itemCurrency,
+        rate,
+        converted: convertAmount({ amount, from: itemCurrency, to: orderCurrency, rate }),
+      };
+    });
+    const totalAmount = itemsWithConversion.reduce((acc, i) => acc + i.converted, 0);
     const retentions = (parsed.data.retentions ?? []).map((r) => ({
       tax_type_id: r.tax_type_id,
       base_amount: Math.round(Number(r.base_amount) * 100) / 100,
@@ -682,16 +734,21 @@ export async function updatePaymentOrder(id: string, data: PaymentOrderFormData)
           scheduled_payment_date: parsed.data.scheduled_payment_date
             ? new Date(parsed.data.scheduled_payment_date)
             : null,
+          currency: orderCurrency,
+          exchange_rate: parsed.data.exchange_rate ?? 1,
           total_amount: Math.round(totalAmount * 100) / 100,
           retentions_total: retentionsTotal,
           net_to_pay: netToPay,
           notes: parsed.data.notes || null,
           items: {
-            create: parsed.data.items.map((i) => ({
+            create: itemsWithConversion.map((i) => ({
               invoice_id: i.invoice_id || null,
               expense_id: i.expense_id || null,
               is_on_account: i.is_on_account ?? false,
-              amount: parseFloat(i.amount),
+              amount: i.amount,
+              currency: i.itemCurrency,
+              exchange_rate: i.rate,
+              amount_in_order_currency: i.converted,
             })),
           },
           payments: {

--- a/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
+++ b/src/modules/treasury/features/payment-orders/components/NewPaymentOrderForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { formatDateUTC } from '@/shared/lib/utils/formatters';
@@ -43,6 +43,13 @@ import {
   getSupplierPaymentMethodsForPaymentOrder,
 } from '../actions.server';
 import { PAYMENT_METHOD_LABELS } from '../../../shared/validators';
+import {
+  BASE_CURRENCY,
+  convertAmount,
+  currencySymbol,
+  effectiveRate,
+  SUPPORTED_CURRENCIES,
+} from '@/shared/lib/currency-conversion';
 import { CheckPaymentField } from './CheckPaymentField';
 import { formatCbu } from './CopyableCbu';
 
@@ -77,6 +84,9 @@ interface InvoiceOption {
   total: number;
   already_paid: number;
   remaining: number;
+  /** total, already_paid y remaining están en esta moneda (tsk-576). */
+  currency: string;
+  exchange_rate: number;
 }
 
 interface ExpenseOption {
@@ -102,7 +112,12 @@ interface ItemDraft {
   invoice_id: string | null;
   expense_id: string | null;
   invoice_label: string | null;
+  /** Importe en la moneda del comprobante (tsk-576). */
   amount: string;
+  /** Moneda del comprobante. Gastos y pagos a cuenta van siempre en ARS. */
+  currency: string;
+  /** Tipo de cambio del comprobante, usado para convertir a la moneda de la OP. */
+  exchange_rate: number;
   // Importe base (saldo de la factura/gasto) antes de aplicar el descuento.
   base_amount: string;
   // % de descuento aplicado a esta línea (0-100). El amount ya es el neto.
@@ -210,6 +225,9 @@ export interface PaymentOrderEditData {
   id: string;
   supplier_id: string | null;
   date: string;
+  /** Moneda de la orden (tsk-576). Las órdenes viejas no la tienen: caen a ARS. */
+  currency?: string | null;
+  exchange_rate?: number | null;
   scheduled_payment_date: string | null;
   notes: string | null;
   full_number: string;
@@ -218,6 +236,8 @@ export interface PaymentOrderEditData {
     expense_id: string | null;
     invoice_label: string | null;
     amount: string;
+    currency?: string | null;
+    exchange_rate?: number | null;
     discount_pct?: number;
     is_on_account?: boolean;
   }>;
@@ -310,6 +330,17 @@ export function NewPaymentOrderForm({
     initialData?.supplier_id ?? pendingDraft?.supplierId ?? ''
   );
   const [date, setDate] = useState(initialData?.date ?? today());
+  // La orden se arma en pesos por defecto aunque la factura del proveedor esté
+  // en dólares; el usuario puede cambiarla (tsk-576).
+  const [orderCurrency, setOrderCurrency] = useState<string>(
+    initialData?.currency ?? BASE_CURRENCY
+  );
+  // Tipo de cambio de la orden. Solo hace falta cuando la orden está en moneda
+  // extranjera y hay comprobantes en pesos: una factura en pesos trae rate 1 y
+  // no alcanza para convertirla (tsk-576).
+  const [orderExchangeRate, setOrderExchangeRate] = useState<number>(
+    initialData?.exchange_rate ?? 1
+  );
   const [scheduledDate, setScheduledDate] = useState<string>(
     initialData?.scheduled_payment_date ?? ''
   );
@@ -365,6 +396,8 @@ export function NewPaymentOrderForm({
         amount: i.amount,
         base_amount: (Math.round(base * 100) / 100).toFixed(2),
         discount_pct: disc ? String(disc) : '0',
+        currency: i.currency ?? BASE_CURRENCY,
+        exchange_rate: i.exchange_rate ?? 1,
         is_on_account: i.is_on_account ?? false,
       };
     }) ?? []
@@ -458,6 +491,8 @@ export function NewPaymentOrderForm({
         amount: amount.toFixed(2),
         base_amount: amount.toFixed(2),
         discount_pct: '0',
+        currency: inv.currency ?? 'ARS',
+        exchange_rate: inv.exchange_rate || 1,
         is_on_account: false,
       });
       totalAmount += amount;
@@ -495,13 +530,29 @@ export function NewPaymentOrderForm({
     setSupplierId(newId);
   };
 
+  // Los totales van en la moneda de la orden: sumar los importes crudos
+  // mezclaría dólares con pesos (tsk-576).
+  const toOrderCurrency = useCallback(
+    (amount: number, item: Pick<ItemDraft, 'currency' | 'exchange_rate'>) =>
+      convertAmount({
+        amount,
+        from: item.currency,
+        to: orderCurrency,
+        rate: effectiveRate(item, {
+          currency: orderCurrency,
+          exchange_rate: orderExchangeRate,
+        }),
+      }),
+    [orderCurrency, orderExchangeRate]
+  );
+
   const itemsTotal = useMemo(
-    () => items.reduce((acc, i) => acc + (parseFloat(i.amount) || 0), 0),
-    [items]
+    () => items.reduce((acc, i) => acc + toOrderCurrency(parseFloat(i.amount) || 0, i), 0),
+    [items, toOrderCurrency]
   );
   const grossItemsTotal = useMemo(
-    () => items.reduce((acc, i) => acc + (parseFloat(i.base_amount) || 0), 0),
-    [items]
+    () => items.reduce((acc, i) => acc + toOrderCurrency(parseFloat(i.base_amount) || 0, i), 0),
+    [items, toOrderCurrency]
   );
   const discountTotal = Math.round((grossItemsTotal - itemsTotal) * 100) / 100;
   const paymentsTotal = useMemo(
@@ -512,6 +563,13 @@ export function NewPaymentOrderForm({
     () => retentions.reduce((acc, r) => acc + (parseFloat(r.amount) || 0), 0),
     [retentions]
   );
+  /** Ítems cuyo comprobante está en una moneda distinta a la de la orden. */
+  const hasForeignItems = useMemo(
+    () => items.some((i) => i.currency !== orderCurrency),
+    [items, orderCurrency]
+  );
+
+  const orderSymbol = currencySymbol(orderCurrency);
   const netToPay = Math.round((itemsTotal - retentionsTotal) * 100) / 100;
   const diff = Math.round((netToPay - paymentsTotal) * 100) / 100;
 
@@ -583,6 +641,10 @@ export function NewPaymentOrderForm({
         base_amount: base,
         discount_pct: globalDiscount,
         amount: netFromDiscount(base, globalDiscount),
+        // El tipo de cambio sale de la factura, no de la cotización del día:
+        // así el importe convertido coincide con lo que se facturó (tsk-576).
+        currency: invoice.currency ?? 'ARS',
+        exchange_rate: invoice.exchange_rate || 1,
         is_on_account: false,
       },
     ]);
@@ -603,6 +665,9 @@ export function NewPaymentOrderForm({
         base_amount: base,
         discount_pct: globalDiscount,
         amount: netFromDiscount(base, globalDiscount),
+        // Los gastos no tienen moneda propia: van siempre en la base.
+        currency: BASE_CURRENCY,
+        exchange_rate: 1,
         is_on_account: false,
       },
     ]);
@@ -624,6 +689,10 @@ export function NewPaymentOrderForm({
         amount: '',
         base_amount: '',
         discount_pct: '0',
+        // Un pago a cuenta no viene de un comprobante: se carga directo en la
+        // moneda de la orden, sin conversión.
+        currency: orderCurrency,
+        exchange_rate: 1,
         is_on_account: true,
       },
     ]);
@@ -726,12 +795,18 @@ export function NewPaymentOrderForm({
       const payload = {
         supplier_id: supplierId || null,
         date,
+        currency: orderCurrency as (typeof SUPPORTED_CURRENCIES)[number],
+        // Tipo de cambio de referencia de la orden: el que se aplica a cada
+        // comprobante viaja en el ítem, porque cada factura trae el suyo.
+        exchange_rate: orderExchangeRate,
         scheduled_payment_date: scheduledDate || null,
         notes: notes.trim() || null,
         items: items.map((i) => ({
           invoice_id: i.invoice_id,
           expense_id: i.expense_id,
           amount: i.amount.trim(),
+          currency: i.currency as (typeof SUPPORTED_CURRENCIES)[number],
+          exchange_rate: i.exchange_rate,
           discount_pct: parseFloat(i.discount_pct) || 0,
           is_on_account: i.is_on_account,
         })),
@@ -811,6 +886,46 @@ export function NewPaymentOrderForm({
               onChange={(e) => setScheduledDate(e.target.value)}
             />
           </div>
+          {/* Moneda de la orden (tsk-576). Arranca en pesos aunque la factura
+              del proveedor esté en dólares. */}
+          <div className="space-y-1.5">
+            <Label>Moneda de la orden</Label>
+            <Select value={orderCurrency} onValueChange={setOrderCurrency}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SUPPORTED_CURRENCIES.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c === 'ARS' ? 'Pesos (ARS)' : 'Dólares (USD)'}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {hasForeignItems && orderCurrency === BASE_CURRENCY && (
+              <p className="text-xs text-muted-foreground">
+                Hay comprobantes en otra moneda. Se convierten con el tipo de cambio de cada factura.
+              </p>
+            )}
+          </div>
+
+          {/* Una factura en pesos trae tipo de cambio 1 y no alcanza para
+              convertirla si la orden está en dólares: ahí lo pone la orden. */}
+          {orderCurrency !== BASE_CURRENCY && (
+            <div className="space-y-1.5">
+              <Label>Tipo de cambio (1 {orderCurrency} = ? {BASE_CURRENCY})</Label>
+              <Input
+                type="number"
+                step="0.0001"
+                min="0"
+                value={orderExchangeRate || ''}
+                onChange={(e) => setOrderExchangeRate(parseFloat(e.target.value) || 0)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Se aplica a los comprobantes en {BASE_CURRENCY}.
+              </p>
+            </div>
+          )}
           <div className="md:col-span-3 space-y-1.5">
             <Label>Notas (opcional)</Label>
             <Textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2} />
@@ -889,14 +1004,25 @@ export function NewPaymentOrderForm({
                             <TableCell className="text-sm">
                               {formatDateUTC(inv.due_date)}
                             </TableCell>
+                            {/* Los importes están en la moneda de la factura, no
+                                en la de la orden: se muestra el símbolo que
+                                corresponde para no confundirlos (tsk-576). */}
                             <TableCell className="text-right font-mono text-sm">
-                              ${inv.total.toFixed(2)}
+                              {currencySymbol(inv.currency)}
+                              {inv.total.toFixed(2)}
                             </TableCell>
                             <TableCell className="text-right font-mono text-sm text-muted-foreground">
-                              ${inv.already_paid.toFixed(2)}
+                              {currencySymbol(inv.currency)}
+                              {inv.already_paid.toFixed(2)}
                             </TableCell>
                             <TableCell className="text-right font-mono font-semibold">
-                              ${inv.remaining.toFixed(2)}
+                              {currencySymbol(inv.currency)}
+                              {inv.remaining.toFixed(2)}
+                              {inv.currency !== orderCurrency && (
+                                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                                  ({inv.currency})
+                                </span>
+                              )}
                             </TableCell>
                             <TableCell className="text-right">
                               <Button
@@ -1004,7 +1130,10 @@ export function NewPaymentOrderForm({
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
             <CardTitle>{paymentTarget === 'expense' ? 'Gastos' : 'Facturas'} ({items.length})</CardTitle>
-            <CardDescription>Importes a pagar — total: ${itemsTotal.toFixed(2)}</CardDescription>
+            <CardDescription>
+              Importes a pagar — total: {orderSymbol}
+              {itemsTotal.toFixed(2)} {orderCurrency}
+            </CardDescription>
           </div>
           <div className="flex items-center gap-2">
             <Label className="text-xs whitespace-nowrap">Descuento global %</Label>
@@ -1105,7 +1234,10 @@ export function NewPaymentOrderForm({
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
             <CardTitle>Pagos ({payments.length})</CardTitle>
-            <CardDescription>Métodos de pago — total: ${paymentsTotal.toFixed(2)}</CardDescription>
+            <CardDescription>
+              Métodos de pago — total: {orderSymbol}
+              {paymentsTotal.toFixed(2)} {orderCurrency}
+            </CardDescription>
           </div>
           <div className="flex items-center gap-2">
             {canLoadPendingBalance && (
@@ -1428,29 +1560,40 @@ export function NewPaymentOrderForm({
                 <div>
                   <span className="text-muted-foreground">Descuento:</span>{' '}
                   <span className="font-mono font-semibold text-amber-600">
-                    −${discountTotal.toFixed(2)}
+                    −{orderSymbol}
+                    {discountTotal.toFixed(2)}
                   </span>
                 </div>
               )}
               <div>
                 <span className="text-muted-foreground">Total {paymentTarget === 'expense' ? 'gastos' : 'facturas'}:</span>{' '}
-                <span className="font-mono font-semibold">${itemsTotal.toFixed(2)}</span>
+                <span className="font-mono font-semibold">
+                  {orderSymbol}
+                  {itemsTotal.toFixed(2)}
+                </span>
               </div>
               {retentionsTotal > 0 && (
                 <div>
                   <span className="text-muted-foreground">Retenciones:</span>{' '}
                   <span className="font-mono font-semibold text-amber-600">
-                    −${retentionsTotal.toFixed(2)}
+                    −{orderSymbol}
+                    {retentionsTotal.toFixed(2)}
                   </span>
                 </div>
               )}
               <div>
                 <span className="text-muted-foreground">Neto a pagar:</span>{' '}
-                <span className="font-mono font-semibold">${netToPay.toFixed(2)}</span>
+                <span className="font-mono font-semibold">
+                  {orderSymbol}
+                  {netToPay.toFixed(2)}
+                </span>
               </div>
               <div>
                 <span className="text-muted-foreground">Total pagos:</span>{' '}
-                <span className="font-mono font-semibold">${paymentsTotal.toFixed(2)}</span>
+                <span className="font-mono font-semibold">
+                  {orderSymbol}
+                  {paymentsTotal.toFixed(2)}
+                </span>
               </div>
               <div>
                 <span className="text-muted-foreground">Diferencia:</span>{' '}

--- a/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
+++ b/src/modules/treasury/features/payment-orders/components/PaymentOrderDetail.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns';
 import { ArrowLeft } from 'lucide-react';
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
+import { currencySymbol } from '@/shared/lib/currency-conversion';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/components/ui/card';
 import {
   Table,
@@ -24,6 +25,9 @@ import {
 export async function PaymentOrderDetail({ id }: { id: string }) {
   const order = await getPaymentOrderById(id);
   if (!order) notFound();
+  // La orden puede estar en dólares (tsk-576): los importes de la orden usan
+  // su símbolo, y cada ítem el de su propio comprobante.
+  const orderSymbol = currencySymbol(order.currency);
 
   const variant =
     order.status === 'PAID'
@@ -71,19 +75,24 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
           <CardHeader>
             <CardDescription>Total facturas</CardDescription>
             <CardTitle className="text-2xl font-mono">
-              ${order.total_amount.toFixed(2)}
+              {orderSymbol}
+              {order.total_amount.toFixed(2)} {order.currency}
             </CardTitle>
             {order.retentions_total > 0 && order.net_to_pay !== null && (
               <div className="text-xs text-muted-foreground space-y-0.5 mt-1">
                 <div>
                   Retenciones:{' '}
                   <span className="font-mono text-amber-600">
-                    −${order.retentions_total.toFixed(2)}
+                    −{orderSymbol}
+                    {order.retentions_total.toFixed(2)}
                   </span>
                 </div>
                 <div>
                   Neto pagado:{' '}
-                  <span className="font-mono font-semibold">${order.net_to_pay.toFixed(2)}</span>
+                  <span className="font-mono font-semibold">
+                    {orderSymbol}
+                    {order.net_to_pay.toFixed(2)}
+                  </span>
                 </div>
               </div>
             )}
@@ -127,16 +136,23 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
                   </TableCell>
                   <TableCell className="text-sm font-mono">
                     {item.invoice
-                      ? `$${item.invoice.total.toFixed(2)}`
+                      ? `${currencySymbol(item.currency)}${item.invoice.total.toFixed(2)}`
                       : item.expense
-                        ? `$${item.expense.amount.toFixed(2)}`
+                        ? `${currencySymbol(item.currency)}${item.expense.amount.toFixed(2)}`
                         : '-'}
                   </TableCell>
                   <TableCell className="text-right font-mono text-sm">
                     {item.discount_pct > 0 ? `${item.discount_pct}%` : '-'}
                   </TableCell>
                   <TableCell className="text-right font-mono font-semibold">
-                    ${item.amount.toFixed(2)}
+                    {currencySymbol(item.currency)}
+                    {item.amount.toFixed(2)}
+                    {item.currency !== order.currency && (
+                      <span className="block text-xs font-normal text-muted-foreground">
+                        = {orderSymbol}
+                        {item.amount_in_order_currency.toFixed(2)} @ {item.exchange_rate}
+                      </span>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}
@@ -204,7 +220,10 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
                     <TableCell className="text-sm text-muted-foreground">
                       {p.reference ?? '-'}
                     </TableCell>
-                    <TableCell className="text-right font-mono">${p.amount.toFixed(2)}</TableCell>
+                    <TableCell className="text-right font-mono">
+                      {orderSymbol}
+                      {p.amount.toFixed(2)}
+                    </TableCell>
                   </TableRow>
                 );
               })}
@@ -243,10 +262,14 @@ export async function PaymentOrderDetail({ id }: { id: string }) {
                         <div className="text-xs text-muted-foreground">{r.tax_type.jurisdiction}</div>
                       )}
                     </TableCell>
-                    <TableCell className="text-right font-mono">${r.base_amount.toFixed(2)}</TableCell>
+                    <TableCell className="text-right font-mono">
+                      {orderSymbol}
+                      {r.base_amount.toFixed(2)}
+                    </TableCell>
                     <TableCell className="text-right font-mono">{r.rate}%</TableCell>
                     <TableCell className="text-right font-mono font-medium text-amber-600">
-                      ${r.amount.toFixed(2)}
+                      {orderSymbol}
+                      {r.amount.toFixed(2)}
                     </TableCell>
                     <TableCell className="font-mono text-xs">
                       {r.certificate_number ? (

--- a/src/modules/treasury/features/payment-orders/components/columns.tsx
+++ b/src/modules/treasury/features/payment-orders/components/columns.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import { PAYMENT_ORDER_STATUS_LABELS } from '../../../shared/validators';
 import { DataTableColumnHeader } from '@/shared/components/data-table';
+import { currencySymbol } from '@/shared/lib/currency-conversion';
 
 function StatusBadge({ status }: { status: string }) {
   const variant =
@@ -73,11 +74,20 @@ export const paymentOrderColumns: ColumnDef<any>[] = [
     accessorKey: 'total_amount',
     header: ({ column }) => <DataTableColumnHeader column={column} title="Total" />,
     meta: { title: 'Total' },
-    cell: ({ row }) => (
-      <span className="text-right font-mono block">
-        ${Number(row.original.total_amount).toFixed(2)}
-      </span>
-    ),
+    cell: ({ row }) => {
+      // Una OP puede estar en dólares (tsk-576): mostrar "$" delante induciría
+      // a error al comparar totales en el listado.
+      const currency = (row.original as { currency?: string }).currency ?? 'ARS';
+      return (
+        <span className="text-right font-mono block">
+          {currencySymbol(currency)}
+          {Number(row.original.total_amount).toFixed(2)}
+          {currency !== 'ARS' && (
+            <span className="ml-1 text-xs text-muted-foreground">{currency}</span>
+          )}
+        </span>
+      );
+    },
   },
   {
     accessorKey: 'status',

--- a/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
+++ b/src/modules/treasury/features/payment-orders/shared/email/sendPaymentOrderPaidEmail.ts
@@ -195,8 +195,11 @@ export async function sendPaymentOrderPaidEmail(
       retentionsTotal: Number(order.retentions_total),
       netToPay:
         order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount,
+      // La orden puede estar en dólares (tsk-576): el importe en letras tiene
+      // que decir DÓLARES, no PESOS.
       amountInWords: amountToSpanishWords(
-        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount
+        order.net_to_pay !== null ? Number(order.net_to_pay) : totalAmount,
+        order.currency
       ),
       pdfSettings,
     };

--- a/src/modules/treasury/features/payment-orders/shared/pdf/amount-in-words.ts
+++ b/src/modules/treasury/features/payment-orders/shared/pdf/amount-in-words.ts
@@ -1,7 +1,16 @@
 /**
  * Convierte un importe numérico a su representación textual en español (Argentina).
- * Formato: "PESOS <enteros> CON <centavos>/100"
+ * Formato: "<MONEDA> <enteros> CON <centavos>/100"
+ *
+ * La moneda es un parámetro desde que las órdenes de pago son multimoneda
+ * (tsk-576): antes decía "PESOS" siempre, así que una orden en dólares salía
+ * con el importe en letras equivocado.
  */
+
+const CURRENCY_WORDS: Record<string, string> = {
+  ARS: 'PESOS',
+  USD: 'DÓLARES',
+};
 
 const UNITS = [
   '',
@@ -84,11 +93,12 @@ function integerToWords(n: number): string {
   return rest === 0 ? millionsText : `${millionsText} ${belowMillion(rest)}`;
 }
 
-export function amountToSpanishWords(amount: number): string {
+export function amountToSpanishWords(amount: number, currency = 'ARS'): string {
   const safe = Math.abs(Math.round(amount * 100) / 100);
   const integerPart = Math.floor(safe);
   const cents = Math.round((safe - integerPart) * 100);
   const words = integerToWords(integerPart).replace(/\s+/g, ' ').trim();
   const centsStr = String(cents).padStart(2, '0');
-  return `PESOS ${words} CON ${centsStr}/100`;
+  const currencyWord = CURRENCY_WORDS[currency] ?? currency;
+  return `${currencyWord} ${words} CON ${centsStr}/100`;
 }

--- a/src/modules/treasury/shared/payment-order-validators.ts
+++ b/src/modules/treasury/shared/payment-order-validators.ts
@@ -1,3 +1,4 @@
+import { convertAmount, effectiveRate, SUPPORTED_CURRENCIES } from '@/shared/lib/currency-conversion';
 import { z } from 'zod';
 
 const amountString = z
@@ -9,7 +10,16 @@ export const paymentOrderItemSchema = z
   .object({
     invoice_id: z.string().uuid().optional().nullable(),
     expense_id: z.string().uuid().optional().nullable(),
+    /** Importe en la moneda del comprobante (tsk-576). */
     amount: amountString.refine((v) => parseFloat(v) > 0, 'Debe ser mayor a 0'),
+    /** Moneda del comprobante. Gastos y pagos a cuenta van en ARS. */
+    currency: z.enum(SUPPORTED_CURRENCIES).optional().default('ARS'),
+    /** Tipo de cambio aplicado, tomado de la factura. */
+    exchange_rate: z.coerce
+      .number()
+      .positive('El tipo de cambio debe ser mayor a 0')
+      .optional()
+      .default(1),
     discount_pct: z.coerce
       .number()
       .min(0, 'El descuento no puede ser negativo')
@@ -111,6 +121,16 @@ export type PaymentOrderRetentionFormData = z.infer<typeof paymentOrderRetention
 export const paymentOrderSchema = z
   .object({
     supplier_id: z.string().uuid().optional().nullable(),
+    /**
+     * Moneda de la orden (tsk-576). Por defecto ARS, incluso cuando la factura
+     * del proveedor está en dólares: el usuario puede cambiarla.
+     */
+    currency: z.enum(SUPPORTED_CURRENCIES).optional().default('ARS'),
+    exchange_rate: z.coerce
+      .number()
+      .positive('El tipo de cambio debe ser mayor a 0')
+      .optional()
+      .default(1),
     date: z.string().min(1, 'Fecha requerida'),
     scheduled_payment_date: z
       .string()
@@ -124,7 +144,21 @@ export const paymentOrderSchema = z
   })
   .refine(
     (data) => {
-      const itemsTotal = data.items.reduce((acc, i) => acc + parseFloat(i.amount), 0);
+      // El cuadre se hace en la moneda de la orden: sumar los `amount` crudos
+      // mezclaría dólares con pesos (tsk-576).
+      const order = { currency: data.currency ?? 'ARS', exchange_rate: data.exchange_rate ?? 1 };
+      const itemsTotal = data.items.reduce((acc, i) => {
+        const item = { currency: i.currency ?? 'ARS', exchange_rate: i.exchange_rate ?? 1 };
+        return (
+          acc +
+          convertAmount({
+            amount: parseFloat(i.amount),
+            from: item.currency,
+            to: order.currency,
+            rate: effectiveRate(item, order),
+          })
+        );
+      }, 0);
       const paymentsTotal = data.payments.reduce((acc, p) => acc + parseFloat(p.amount), 0);
       const retentionsTotal = (data.retentions ?? []).reduce(
         (acc, r) => acc + (Number(r.amount) || 0),
@@ -148,5 +182,23 @@ export const paymentOrderSchema = z
         message: 'Un pago a cuenta requiere seleccionar el proveedor',
       });
     }
+
+    // Un comprobante en otra moneda necesita un tipo de cambio explícito: con
+    // rate = 1 se pagaría una factura en dólares como si fueran pesos, que es
+    // justamente el error que esta tarea corrige (tsk-576).
+    const order = { currency: data.currency ?? 'ARS', exchange_rate: data.exchange_rate ?? 1 };
+    data.items.forEach((i, index) => {
+      const item = { currency: i.currency ?? 'ARS', exchange_rate: i.exchange_rate ?? 1 };
+      if (item.currency === order.currency) return;
+      // El rate puede venir de la factura o, si la factura está en pesos y la
+      // orden en dólares, de la propia orden.
+      if (effectiveRate(item, order) <= 1) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['items', index, 'exchange_rate'],
+          message: `El comprobante está en ${item.currency} y la orden en ${order.currency}: falta el tipo de cambio`,
+        });
+      }
+    });
   });
 export type PaymentOrderFormData = z.infer<typeof paymentOrderSchema>;

--- a/src/shared/lib/currency-conversion.ts
+++ b/src/shared/lib/currency-conversion.ts
@@ -1,0 +1,116 @@
+/**
+ * Conversión de importes entre monedas para órdenes de pago (tsk-576).
+ *
+ * Vive en `shared` porque lo necesitan tesorería (armar la OP) y el formulario
+ * cliente, y los módulos no pueden importarse entre sí. Es puro: sin Prisma,
+ * testeable aislado, igual que `purchase-invoice-balance.ts`.
+ *
+ * Convención del tipo de cambio: `rate` es siempre cuántas unidades de la moneda
+ * base (ARS) vale UNA unidad de la moneda extranjera. Un dólar a $1250 es
+ * rate = 1250, tanto para convertir de USD a ARS como al revés.
+ */
+
+export const BASE_CURRENCY = 'ARS';
+
+export const SUPPORTED_CURRENCIES = ['ARS', 'USD'] as const;
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export function currencySymbol(currency: string): string {
+  return currency === 'USD' ? 'US$' : '$';
+}
+
+/**
+ * Convierte un importe de la moneda de un comprobante a la moneda de la orden.
+ *
+ * Los tres casos:
+ *   - misma moneda            -> el importe no se toca (ni siquiera se redondea
+ *                                por un rate que no se usó)
+ *   - extranjera -> base      -> multiplica por el tipo de cambio
+ *   - base -> extranjera      -> divide por el tipo de cambio
+ *
+ * Un `rate` no positivo devuelve el importe sin convertir: es un dato inválido y
+ * multiplicar por cero borraría plata de la orden en silencio. Quien llame debe
+ * validar el rate antes (ver `isValidExchangeRate`).
+ */
+export function convertAmount({
+  amount,
+  from,
+  to,
+  rate,
+}: {
+  amount: number;
+  from: string;
+  to: string;
+  rate: number;
+}): number {
+  if (from === to) return round2(amount);
+  if (!Number.isFinite(rate) || rate <= 0) return round2(amount);
+
+  if (to === BASE_CURRENCY) return round2(amount * rate);
+  if (from === BASE_CURRENCY) return round2(amount / rate);
+
+  // Cruce entre dos monedas extranjeras: hoy no se da (solo ARS y USD), pero
+  // dejarlo explícito evita una conversión silenciosamente incorrecta si se
+  // agrega una tercera moneda.
+  return round2(amount);
+}
+
+export function isValidExchangeRate(rate: unknown): rate is number {
+  const n = Number(rate);
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Tipo de cambio que hay que aplicarle realmente a un ítem.
+ *
+ * El rate sale de la factura, pero una factura EN PESOS trae rate = 1, que no
+ * alcanza para convertirla cuando la orden está en dólares. En ese caso el rate
+ * lo aporta la orden. Los tres casos:
+ *
+ *   ítem y orden en la misma moneda        -> 1 (no se convierte)
+ *   ítem en moneda extranjera              -> el de la factura
+ *   ítem en la base, orden en extranjera   -> el de la orden
+ */
+export function effectiveRate(
+  item: { currency: string; exchange_rate: number },
+  order: { currency: string; exchange_rate: number }
+): number {
+  if (item.currency === order.currency) return 1;
+  if (item.currency !== BASE_CURRENCY && isValidExchangeRate(item.exchange_rate) && item.exchange_rate > 1) {
+    return item.exchange_rate;
+  }
+  return isValidExchangeRate(order.exchange_rate) ? order.exchange_rate : 1;
+}
+
+/**
+ * Un ítem de la orden necesita un tipo de cambio explícito solo cuando su
+ * comprobante está en una moneda distinta a la de la orden.
+ */
+export function needsExchangeRate(itemCurrency: string, orderCurrency: string): boolean {
+  return itemCurrency !== orderCurrency;
+}
+
+/**
+ * Suma los importes de los ítems ya expresados en la moneda de la orden.
+ * Es la única suma válida: sumar `amount` mezclaría monedas.
+ */
+export function sumInOrderCurrency(
+  items: Array<{ amount: number; currency: string; exchange_rate: number }>,
+  order: { currency: string; exchange_rate: number }
+): number {
+  return round2(
+    items.reduce(
+      (acc, item) =>
+        acc +
+        convertAmount({
+          amount: item.amount,
+          from: item.currency,
+          to: order.currency,
+          rate: effectiveRate(item, order),
+        }),
+      0
+    )
+  );
+}

--- a/src/shared/lib/utils/formatters.ts
+++ b/src/shared/lib/utils/formatters.ts
@@ -45,6 +45,28 @@ export function formatCurrencyARS(value: number | null | undefined): string {
 }
 
 /**
+ * Formatea un importe en la moneda indicada, con el mismo estilo de separadores
+ * que `formatCurrencyARS`.
+ *
+ * Existe porque las órdenes de pago pasaron a ser multimoneda (tsk-576) y
+ * mostrar "$" delante de un importe en dólares induce a error.
+ * Ejemplo: (150, 'USD') → 'US$ 150,00'
+ */
+export function formatCurrencyIn(
+  value: number | null | undefined,
+  currency: string | null | undefined
+): string {
+  if (value == null || isNaN(value)) return '—';
+  if (!currency || currency === 'ARS') return arsFormatter.format(value);
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+/**
  * Formatea un número decimal como porcentaje.
  * Retorna '—' para null/undefined/NaN.
  * Ejemplo: 0.85 → '85,00%'

--- a/supabase/migrations/20260814191334_payment_order_multicurrency.sql
+++ b/supabase/migrations/20260814191334_payment_order_multicurrency.sql
@@ -1,0 +1,60 @@
+-- Órdenes de pago multimoneda (tsk-576).
+--
+-- Hasta ahora la OP no tenía moneda: sumaba los importes de los comprobantes tal
+-- cual, así que una factura en USD se sumaba a una en ARS como si fueran la
+-- misma unidad. La OP pasa a tener moneda propia — por defecto ARS, incluso
+-- cuando la factura del proveedor está en dólares — y cada ítem guarda su
+-- importe en las dos monedas.
+--
+-- Migración ADD-only y retrocompatible: los defaults ('ARS', tipo de cambio 1)
+-- reproducen exactamente el comportamiento actual sobre los datos existentes.
+
+-- ============================================================
+-- 1) payment_orders: moneda de la orden
+-- ============================================================
+-- total_amount, retentions_total y net_to_pay quedan expresados en esta moneda.
+-- exchange_rate es de referencia: el que efectivamente se aplicó a cada ítem se
+-- guarda por ítem, porque cada comprobante puede tener el suyo.
+
+ALTER TABLE "payment_orders"
+  ADD COLUMN IF NOT EXISTS "currency"      text    NOT NULL DEFAULT 'ARS',
+  ADD COLUMN IF NOT EXISTS "exchange_rate" numeric(15,4) NOT NULL DEFAULT 1;
+
+-- ============================================================
+-- 2) payment_order_items: importe en las dos monedas
+-- ============================================================
+-- `amount` NO cambia de significado: sigue siendo el importe imputado EN LA
+-- MONEDA DEL COMPROBANTE. Es lo que hace que el saldo de una factura en dólares
+-- cierre contra su propio total, sin depender de ningún tipo de cambio al leer.
+--
+-- `amount_in_order_currency` es ese mismo importe convertido a la moneda de la
+-- OP, y es lo que suma para total_amount y para el cuadre contra los pagos.
+--
+-- `exchange_rate` es el tipo de cambio aplicado a este ítem, tomado de la
+-- factura (snapshot: no se recalcula si la cotización cambia después).
+
+ALTER TABLE "payment_order_items"
+  ADD COLUMN IF NOT EXISTS "currency"                 text    NOT NULL DEFAULT 'ARS',
+  ADD COLUMN IF NOT EXISTS "exchange_rate"            numeric(15,4) NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS "amount_in_order_currency" numeric(15,2);
+
+-- Backfill: hasta hoy todo se trataba como una sola moneda, así que el importe
+-- convertido es el mismo importe. Se hace antes del NOT NULL para que las filas
+-- existentes queden consistentes.
+UPDATE "payment_order_items"
+   SET "amount_in_order_currency" = "amount"
+ WHERE "amount_in_order_currency" IS NULL;
+
+ALTER TABLE "payment_order_items"
+  ALTER COLUMN "amount_in_order_currency" SET NOT NULL;
+
+-- Las facturas ya cargadas en dólares tienen su moneda en purchase_invoices:
+-- se refleja en los ítems que las imputan para no perder el dato histórico.
+-- El importe convertido no se toca: los datos viejos se cargaron sin conversión
+-- y recalcularlos ahora inventaría un tipo de cambio que nadie eligió.
+UPDATE "payment_order_items" i
+   SET "currency" = pi."currency"
+  FROM "purchase_invoices" pi
+ WHERE i."invoice_id" = pi."id"
+   AND pi."currency" IS NOT NULL
+   AND pi."currency" <> 'ARS';


### PR DESCRIPTION
La OP no tenía moneda: createPaymentOrder sumaba los importes de los comprobantes tal cual, así que una factura en dólares se sumaba a una en pesos como si fueran la misma unidad. El backfill de la migración encontró un ítem ya imputado a una factura en USD, o sea que el problema ya ocurrió con datos reales.

La orden pasa a tener moneda propia, por defecto ARS incluso cuando la factura del proveedor está en dólares, y se puede cambiar desde el formulario.

Dónde se guarda la imputación (migración ADD-only 20260814191334):
- payment_order_items.amount NO cambia de significado: sigue siendo el importe en la moneda del comprobante. Es lo que hace que el saldo de una factura en dólares cierre contra su propio total sin depender de ningún tipo de cambio al leer, y evita reinterpretar los datos ya cargados.
- amount_in_order_currency es ese importe convertido, y es lo que suma para total_amount y lo que cuadra contra los pagos.
- Los defaults ('ARS', rate 1) reproducen el comportamiento actual sobre lo existente. El backfill no inventa conversiones retroactivas: los datos viejos se cargaron sin conversión y recalcularlos ahora sería inventar un tipo de cambio que nadie eligió.

El tipo de cambio sale de la factura, como snapshot. Pero una factura EN PESOS trae rate 1, que no alcanza para convertirla si la orden está en dólares: ahí lo aporta la orden. Eso resuelve effectiveRate(), y el formulario pide el tipo de cambio de la orden solo en ese caso.

shared/lib/currency-conversion.ts es puro y testeable, como purchase-invoice-balance.ts, porque lo necesitan tesorería y el formulario cliente. Un rate no positivo devuelve el importe sin convertir en vez de multiplicar por cero y borrar plata en silencio.

El PDF decía "PESOS" hardcodeado en el importe en letras: ahora depende de la moneda. El detalle, el listado y la tabla de facturas pendientes muestran cada importe con el símbolo que corresponde.

Notas de crédito (tercer punto del ticket): ya funcionaba, no hubo que tocar nada. No se pueden incluir en una OP — se excluyen en getPendingPurchaseInvoices — y sí descuentan saldo, imputándose contra su factura original; solo queda como crédito a favor lo que exceda el saldo de esa factura.

Verificado: tsc limpio, prisma sin drift, 19 casos de conversión y validación en verde (incluida la retrocompatibilidad de órdenes sin moneda y el rechazo del bug viejo), y contra la base una factura de 150 USD @1250 pagada por una OP en pesos de $187.500 deja el saldo de la factura en 0 USD.